### PR TITLE
FI-2187: Support for Multiple Patient Search

### DIFF
--- a/lib/carin_for_blue_button_test_kit/carin_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/carin_search_test.rb
@@ -25,6 +25,10 @@ module CarinForBlueButtonTestKit
                    :params_with_comparators,
                    :multiple_or_search_params
 
+    def all_scratch_resources
+      scratch_resources[:all] ||= []
+    end
+
     def run_search_test(param_value, include_search: false, resource_id: nil)
       search_params = {}
 
@@ -45,6 +49,8 @@ module CarinForBlueButtonTestKit
       end
 
       skip_if returned_resources.blank?, no_resources_message
+
+      all_scratch_resources.concat(returned_resources).uniq! if first_search?
 
       returned_resources.each do |resource|
         check_resource_against_params(resource, search_params)
@@ -146,7 +152,8 @@ module CarinForBlueButtonTestKit
                         when 'Period', 'date', 'instant', 'dateTime'
                           values_found.any? { |date| validate_date_search(param_value, date) }
                         when 'http://hl7.org/fhirpath/System.String'
-                          values_found.any? { |str| param_value == str }
+                          param_value = param_value.split(',').map(&:strip)
+                          values_found.any? { |str| param_value.include?(str) }
                         else
                           false
                         end

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/patient/patient_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/patient/patient_id_search_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative '../../../carin_search_test'
+require_relative '../../../generator/group_metadata'
+
+module CarinForBlueButtonTestKit
+  module CARIN4BBV110
+    class PatientIdSearchTest < Inferno::Test
+      include CarinForBlueButtonTestKit::CarinSearchTest
+
+      title 'Server returns valid results for Patient search by _id'
+      description %(
+        A server SHALL support searching by
+        _id on the Patient resource. This test
+        will pass if resources are returned and match the search criteria. If
+        none are returned, the test is skipped.
+
+        Because this is the first search of the sequence, resources in the
+        response will be used for subsequent tests.
+
+      )
+
+      id :c4bb_v110_patient_id_search_test
+      input :patient_ids,
+            title: 'Patient IDs',
+            description: 'Comma separated list of patient IDs (e.g. patient1,patient2)'
+
+      def self.properties
+        @properties ||= SearchTestProperties.new(
+          first_search: true,
+          resource_type: 'Patient',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+      end
+
+      def scratch_resources
+        scratch[:patient_resources] ||= {}
+      end
+
+      run do
+        run_search_test(patient_ids)
+      end
+    end
+  end
+end

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/patient_group.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/patient_group.rb
@@ -1,58 +1,62 @@
+# frozen_string_literal: true
+
+require_relative 'patient/patient_id_search_test'
 require_relative 'patient/patient_read_test'
-    require_relative 'patient/patient_validation_test'
-    require_relative 'patient/patient_must_support_test'
-    
-    module CarinForBlueButtonTestKit
-      module CARIN4BBV110
-        class PatientGroup < Inferno::TestGroup
-          title 'Patient Tests'
-          short_description 'Verify support for the server capabilities required by the C4BB Patient.'
-          description %(
-      # Background
+require_relative 'patient/patient_validation_test'
+require_relative 'patient/patient_must_support_test'
 
-The CARIN for Blue Button Patient sequence verifies that the system under test is
-able to provide correct responses for Patient queries. These queries
-must contain resources conforming to the C4BB Patient as
-specified in the CARIN for Blue Button v1.1.0 Implementation Guide.
+module CarinForBlueButtonTestKit
+  module CARIN4BBV110
+    class PatientGroup < Inferno::TestGroup
+      title 'Patient Tests'
+      short_description 'Verify support for the server capabilities required by the C4BB Patient.'
+      description %(
+        # Background
 
-# Testing Methodology
+        The CARIN for Blue Button Patient sequence verifies that the system under test is
+        able to provide correct responses for Patient queries. These queries
+        must contain resources conforming to the C4BB Patient as
+        specified in the CARIN for Blue Button v1.1.0 Implementation Guide.
+
+        # Testing Methodology
 
 
-## Must Support
-Each profile contains elements marked as "must support". This test
-sequence expects to see each of these elements at least once. If at
-least one cannot be found, the test will fail. The test will look
-through the Patient resources found in the first test for these
-elements.
+        ## Must Support
+        Each profile contains elements marked as "must support". This test
+        sequence expects to see each of these elements at least once. If at
+        least one cannot be found, the test will fail. The test will look
+        through the Patient resources found in the first test for these
+        elements.
 
-## Profile Validation
-Each resource returned from the first search is expected to conform to
-the [C4BB Patient](http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Patient). Each element is checked against
-terminology binding and cardinality requirements.
+        ## Profile Validation
+        Each resource returned from the first search is expected to conform to
+        the [C4BB Patient](http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Patient). Each element is checked
+        against terminology binding and cardinality requirements.
 
-Elements with a required binding are validated against their bound
-ValueSet. If the code/system in the element is not part of the ValueSet,
-then the test will fail.
+        Elements with a required binding are validated against their bound
+        ValueSet. If the code/system in the element is not part of the ValueSet,
+        then the test will fail.
 
-## Reference Validation
-At least one instance of each external reference in elements marked as
-"must support" within the resources provided by the system must resolve.
-The test will attempt to read each reference found and will fail if no
-read succeeds.
+        ## Reference Validation
+        At least one instance of each external reference in elements marked as
+        "must support" within the resources provided by the system must resolve.
+        The test will attempt to read each reference found and will fail if no
+        read succeeds.
 
-          )
-    
-          id :c4bb_v110_patient
-          run_as_group
-    
-          def self.metadata
-            @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'patient', 'metadata.yml'), aliases: true))
-          end
-      
-          test from: :c4bb_v110_patient_read_test
-          test from: :c4bb_v110_patient_validation_test
-          test from: :c4bb_v110_patient_must_support_test
-        end
+      )
+
+      id :c4bb_v110_patient
+      run_as_group
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'patient', 'metadata.yml'),
+                                                                  aliases: true))
       end
+
+      test from: :c4bb_v110_patient_id_search_test
+      test from: :c4bb_v110_patient_read_test
+      test from: :c4bb_v110_patient_validation_test
+      test from: :c4bb_v110_patient_must_support_test
     end
-    
+  end
+end

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient/patient_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient/patient_id_search_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative '../../../carin_search_test'
+require_relative '../../../generator/group_metadata'
+
+module CarinForBlueButtonTestKit
+  module CARIN4BBV200DEVNONFINANCIAL
+    class PatientIdSearchTest < Inferno::Test
+      include CarinForBlueButtonTestKit::CarinSearchTest
+
+      title 'Server returns valid results for Patient search by _id'
+      description %(
+        A server SHALL support searching by
+        _id on the Patient resource. This test
+        will pass if resources are returned and match the search criteria. If
+        none are returned, the test is skipped.
+
+        Because this is the first search of the sequence, resources in the
+        response will be used for subsequent tests.
+
+      )
+
+      id :c4bb_v200devnonfinancial_patient_id_search_test
+      input :patient_ids,
+            title: 'Patient IDs',
+            description: 'Comma separated list of patient IDs (e.g. patient1,patient2)'
+
+      def self.properties
+        @properties ||= SearchTestProperties.new(
+          first_search: true,
+          resource_type: 'Patient',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+      end
+
+      def scratch_resources
+        scratch[:patient_resources] ||= {}
+      end
+
+      run do
+        run_search_test(patient_ids)
+      end
+    end
+  end
+end

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient_group.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient_group.rb
@@ -1,81 +1,85 @@
+# frozen_string_literal: true
+
+require_relative 'patient/patient_id_search_test'
 require_relative 'patient/patient_read_test'
-    require_relative 'patient/patient_validation_test'
-    require_relative 'patient/patient_must_support_test'
-    
-    module CarinForBlueButtonTestKit
-      module CARIN4BBV200DEVNONFINANCIAL
-        class PatientGroup < Inferno::TestGroup
-          title 'Patient Tests'
-          short_description 'Verify support for the server capabilities required by the C4BB Patient.'
-          description %(
-      # Background
+require_relative 'patient/patient_validation_test'
+require_relative 'patient/patient_must_support_test'
 
-The CARIN for Blue Button Patient sequence verifies that the system under test is
-able to provide correct responses for Patient queries. These queries
-must contain resources conforming to the C4BB Patient as
-specified in the CARIN for Blue Button v2.0.0-dev-nonfinancial Implementation Guide.
+module CarinForBlueButtonTestKit
+  module CARIN4BBV200DEVNONFINANCIAL
+    class PatientGroup < Inferno::TestGroup
+      title 'Patient Tests'
+      short_description 'Verify support for the server capabilities required by the C4BB Patient.'
+      description %(
+        # Background
 
-# Testing Methodology
-## Searching
-This test sequence will first perform each required search associated
-with this resource. This sequence will perform searches with the
-following parameters:
+        The CARIN for Blue Button Patient sequence verifies that the system under test is
+        able to provide correct responses for Patient queries. These queries
+        must contain resources conforming to the C4BB Patient as
+        specified in the CARIN for Blue Button v2.0.0-dev-nonfinancial Implementation Guide.
 
-* _id
+        # Testing Methodology
+        ## Searching
+        This test sequence will first perform each required search associated
+        with this resource. This sequence will perform searches with the
+        following parameters:
 
-### Search Parameters
-The first search uses the selected patient(s) from the prior launch
-sequence. Any subsequent searches will look for its parameter values
-from the results of the first search. For example, the `identifier`
-search in the patient sequence is performed by looking for an existing
-`Patient.identifier` from any of the resources returned in the `_id`
-search. If a value cannot be found this way, the search is skipped.
+        * _id
 
-### Search Validation
-Inferno will retrieve up to the first 20 bundle pages of the reply for
-Patient resources and save them for subsequent tests.
-Each resource is then checked to see if it matches the searched
-parameters in accordance with [FHIR search
-guidelines](https://www.hl7.org/fhir/search.html). The test will fail,
-for example, if a Patient search for `gender=male` returns a `female`
-patient.
+        ### Search Parameters
+        The first search uses the selected patient(s) from the prior launch
+        sequence. Any subsequent searches will look for its parameter values
+        from the results of the first search. For example, the `identifier`
+        search in the patient sequence is performed by looking for an existing
+        `Patient.identifier` from any of the resources returned in the `_id`
+        search. If a value cannot be found this way, the search is skipped.
+
+        ### Search Validation
+        Inferno will retrieve up to the first 20 bundle pages of the reply for
+        Patient resources and save them for subsequent tests.
+        Each resource is then checked to see if it matches the searched
+        parameters in accordance with [FHIR search
+        guidelines](https://www.hl7.org/fhir/search.html). The test will fail,
+        for example, if a Patient search for `gender=male` returns a `female`
+        patient.
 
 
-## Must Support
-Each profile contains elements marked as "must support". This test
-sequence expects to see each of these elements at least once. If at
-least one cannot be found, the test will fail. The test will look
-through the Patient resources found in the first test for these
-elements.
+        ## Must Support
+        Each profile contains elements marked as "must support". This test
+        sequence expects to see each of these elements at least once. If at
+        least one cannot be found, the test will fail. The test will look
+        through the Patient resources found in the first test for these
+        elements.
 
-## Profile Validation
-Each resource returned from the first search is expected to conform to
-the [C4BB Patient](http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Patient). Each element is checked against
-terminology binding and cardinality requirements.
+        ## Profile Validation
+        Each resource returned from the first search is expected to conform to
+        the [C4BB Patient](http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Patient).
+        Each element is checked against terminology binding and cardinality requirements.
 
-Elements with a required binding are validated against their bound
-ValueSet. If the code/system in the element is not part of the ValueSet,
-then the test will fail.
+        Elements with a required binding are validated against their bound
+        ValueSet. If the code/system in the element is not part of the ValueSet,
+        then the test will fail.
 
-## Reference Validation
-At least one instance of each external reference in elements marked as
-"must support" within the resources provided by the system must resolve.
-The test will attempt to read each reference found and will fail if no
-read succeeds.
+        ## Reference Validation
+        At least one instance of each external reference in elements marked as
+        "must support" within the resources provided by the system must resolve.
+        The test will attempt to read each reference found and will fail if no
+        read succeeds.
 
-          )
-    
-          id :c4bb_v200devnonfinancial_patient
-          run_as_group
-    
-          def self.metadata
-            @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'patient', 'metadata.yml'), aliases: true))
-          end
-      
-          test from: :c4bb_v200devnonfinancial_patient_read_test
-          test from: :c4bb_v200devnonfinancial_patient_validation_test
-          test from: :c4bb_v200devnonfinancial_patient_must_support_test
-        end
+      )
+
+      id :c4bb_v200devnonfinancial_patient
+      run_as_group
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'patient', 'metadata.yml'),
+                                                                  aliases: true))
       end
+
+      test from: :c4bb_v200devnonfinancial_patient_id_search_test
+      test from: :c4bb_v200devnonfinancial_patient_read_test
+      test from: :c4bb_v200devnonfinancial_patient_validation_test
+      test from: :c4bb_v200devnonfinancial_patient_must_support_test
     end
-    
+  end
+end

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient/patient_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient/patient_id_search_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative '../../../carin_search_test'
+require_relative '../../../generator/group_metadata'
+
+module CarinForBlueButtonTestKit
+  module CARIN4BBV200
+    class PatientIdSearchTest < Inferno::Test
+      include CarinForBlueButtonTestKit::CarinSearchTest
+
+      title 'Server returns valid results for Patient search by _id'
+      description %(
+        A server SHALL support searching by
+        _id on the Patient resource. This test
+        will pass if resources are returned and match the search criteria. If
+        none are returned, the test is skipped.
+
+        Because this is the first search of the sequence, resources in the
+        response will be used for subsequent tests.
+
+      )
+
+      id :c4bb_v200_patient_id_search_test
+      input :patient_ids,
+            title: 'Patient IDs',
+            description: 'Comma separated list of patient IDs (e.g. patient1,patient2)'
+
+      def self.properties
+        @properties ||= SearchTestProperties.new(
+          first_search: true,
+          resource_type: 'Patient',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+      end
+
+      def scratch_resources
+        scratch[:patient_resources] ||= {}
+      end
+
+      run do
+        run_search_test(patient_ids)
+      end
+    end
+  end
+end

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient_group.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient_group.rb
@@ -1,81 +1,85 @@
+# frozen_string_literal: true
+
+require_relative 'patient/patient_id_search_test'
 require_relative 'patient/patient_read_test'
-    require_relative 'patient/patient_validation_test'
-    require_relative 'patient/patient_must_support_test'
-    
-    module CarinForBlueButtonTestKit
-      module CARIN4BBV200
-        class PatientGroup < Inferno::TestGroup
-          title 'Patient Tests'
-          short_description 'Verify support for the server capabilities required by the C4BB Patient.'
-          description %(
-      # Background
+require_relative 'patient/patient_validation_test'
+require_relative 'patient/patient_must_support_test'
 
-The CARIN for Blue Button Patient sequence verifies that the system under test is
-able to provide correct responses for Patient queries. These queries
-must contain resources conforming to the C4BB Patient as
-specified in the CARIN for Blue Button v2.0.0 Implementation Guide.
+module CarinForBlueButtonTestKit
+  module CARIN4BBV200
+    class PatientGroup < Inferno::TestGroup
+      title 'Patient Tests'
+      short_description 'Verify support for the server capabilities required by the C4BB Patient.'
+      description %(
+        # Background
 
-# Testing Methodology
-## Searching
-This test sequence will first perform each required search associated
-with this resource. This sequence will perform searches with the
-following parameters:
+        The CARIN for Blue Button Patient sequence verifies that the system under test is
+        able to provide correct responses for Patient queries. These queries
+        must contain resources conforming to the C4BB Patient as
+        specified in the CARIN for Blue Button v2.0.0 Implementation Guide.
 
-* _id
+        # Testing Methodology
+        ## Searching
+        This test sequence will first perform each required search associated
+        with this resource. This sequence will perform searches with the
+        following parameters:
 
-### Search Parameters
-The first search uses the selected patient(s) from the prior launch
-sequence. Any subsequent searches will look for its parameter values
-from the results of the first search. For example, the `identifier`
-search in the patient sequence is performed by looking for an existing
-`Patient.identifier` from any of the resources returned in the `_id`
-search. If a value cannot be found this way, the search is skipped.
+        * _id
 
-### Search Validation
-Inferno will retrieve up to the first 20 bundle pages of the reply for
-Patient resources and save them for subsequent tests.
-Each resource is then checked to see if it matches the searched
-parameters in accordance with [FHIR search
-guidelines](https://www.hl7.org/fhir/search.html). The test will fail,
-for example, if a Patient search for `gender=male` returns a `female`
-patient.
+        ### Search Parameters
+        The first search uses the selected patient(s) from the prior launch
+        sequence. Any subsequent searches will look for its parameter values
+        from the results of the first search. For example, the `identifier`
+        search in the patient sequence is performed by looking for an existing
+        `Patient.identifier` from any of the resources returned in the `_id`
+        search. If a value cannot be found this way, the search is skipped.
+
+        ### Search Validation
+        Inferno will retrieve up to the first 20 bundle pages of the reply for
+        Patient resources and save them for subsequent tests.
+        Each resource is then checked to see if it matches the searched
+        parameters in accordance with [FHIR search
+        guidelines](https://www.hl7.org/fhir/search.html). The test will fail,
+        for example, if a Patient search for `gender=male` returns a `female`
+        patient.
 
 
-## Must Support
-Each profile contains elements marked as "must support". This test
-sequence expects to see each of these elements at least once. If at
-least one cannot be found, the test will fail. The test will look
-through the Patient resources found in the first test for these
-elements.
+        ## Must Support
+        Each profile contains elements marked as "must support". This test
+        sequence expects to see each of these elements at least once. If at
+        least one cannot be found, the test will fail. The test will look
+        through the Patient resources found in the first test for these
+        elements.
 
-## Profile Validation
-Each resource returned from the first search is expected to conform to
-the [C4BB Patient](http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Patient). Each element is checked against
-terminology binding and cardinality requirements.
+        ## Profile Validation
+        Each resource returned from the first search is expected to conform to
+        the [C4BB Patient](http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Patient).
+        Each element is checked against terminology binding and cardinality requirements.
 
-Elements with a required binding are validated against their bound
-ValueSet. If the code/system in the element is not part of the ValueSet,
-then the test will fail.
+        Elements with a required binding are validated against their bound
+        ValueSet. If the code/system in the element is not part of the ValueSet,
+        then the test will fail.
 
-## Reference Validation
-At least one instance of each external reference in elements marked as
-"must support" within the resources provided by the system must resolve.
-The test will attempt to read each reference found and will fail if no
-read succeeds.
+        ## Reference Validation
+        At least one instance of each external reference in elements marked as
+        "must support" within the resources provided by the system must resolve.
+        The test will attempt to read each reference found and will fail if no
+        read succeeds.
 
-          )
-    
-          id :c4bb_v200_patient
-          run_as_group
-    
-          def self.metadata
-            @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'patient', 'metadata.yml'), aliases: true))
-          end
-      
-          test from: :c4bb_v200_patient_read_test
-          test from: :c4bb_v200_patient_validation_test
-          test from: :c4bb_v200_patient_must_support_test
-        end
+      )
+
+      id :c4bb_v200_patient
+      run_as_group
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'patient', 'metadata.yml'),
+                                                                  aliases: true))
       end
+
+      test from: :c4bb_v200_patient_id_search_test
+      test from: :c4bb_v200_patient_read_test
+      test from: :c4bb_v200_patient_validation_test
+      test from: :c4bb_v200_patient_must_support_test
     end
-    
+  end
+end


### PR DESCRIPTION
# Summary
This PR adds test patient search by _id for all the IGs version currently supported.  
The test will pass if resources are returned and match the search criteria. If none are returned, the test is skipped.
Test allow SUT to provide multiple patient ids as an input `Comma separated list of patient IDs (e.g. patient1,patient2)` and resources in the response are used for subsequent tests in the group.

<img width="1773" alt="Screenshot 2023-10-25 at 4 21 07 PM" src="https://github.com/inferno-framework/carin-for-blue-button-test-kit/assets/46642178/23b7a379-57a2-44a6-8558-04c4fd3cc14f">

<img width="1773" alt="Screenshot 2023-10-25 at 4 21 44 PM" src="https://github.com/inferno-framework/carin-for-blue-button-test-kit/assets/46642178/504c486f-54a9-4d64-8627-eb8df682a99a">

# Testing Guidance
Run the unit test & ensure everything passes.

Web Testing: was tested using a local instance of the [C4BB RI](https://github.com/vanessuniq/cpcds-server-ri)
