### PR TITLE
Fi 2187 multi patient search support

### DIFF
--- a/lib/carin_for_blue_button_test_kit/carin_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/carin_search_test.rb
@@ -135,7 +135,7 @@ module CarinForBlueButtonTestKit
           values_found =
             resolve_path(resource, path)
             .map do |value|
-              value&.reference || value
+              value.try(:reference) || value
             end
 
           match_found = case type

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       id :c4bb_v110_explanation_of_benefit__id_search_test
 
       input :c4bb_v110_explanation_of_benefit__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_identifier_search_test
 
       input :c4bb_v110_explanation_of_benefit_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit__lastUpdated_search_test
 
       input :c4bb_v110_explanation_of_benefit__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_patient_search_test
 
       input :c4bb_v110_explanation_of_benefit_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_service_date_search_test
 
       input :c4bb_v110_explanation_of_benefit_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit/explanation_of_benefit_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_type_search_test
 
       input :c4bb_v110_explanation_of_benefit_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       id :c4bb_v110_explanation_of_benefit_inpatient_institutional__id_search_test
 
       input :c4bb_v110_explanation_of_benefit_inpatient_institutional__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_inpatient_institutional__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_inpatient_institutional_identifier_search_test
 
       input :c4bb_v110_explanation_of_benefit_inpatient_institutional_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_inpatient_institutional_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_inpatient_institutional__lastUpdated_search_test
 
       input :c4bb_v110_explanation_of_benefit_inpatient_institutional__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_inpatient_institutional__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_inpatient_institutional_patient_search_test
 
       input :c4bb_v110_explanation_of_benefit_inpatient_institutional_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_inpatient_institutional_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_inpatient_institutional_service_date_search_test
 
       input :c4bb_v110_explanation_of_benefit_inpatient_institutional_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_inpatient_institutional_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_inpatient_institutional_type_search_test
 
       input :c4bb_v110_explanation_of_benefit_inpatient_institutional_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_inpatient_institutional_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       id :c4bb_v110_explanation_of_benefit_outpatient_institutional__id_search_test
 
       input :c4bb_v110_explanation_of_benefit_outpatient_institutional__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_outpatient_institutional__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_outpatient_institutional_identifier_search_test
 
       input :c4bb_v110_explanation_of_benefit_outpatient_institutional_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_outpatient_institutional_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_outpatient_institutional__lastUpdated_search_test
 
       input :c4bb_v110_explanation_of_benefit_outpatient_institutional__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_outpatient_institutional__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_outpatient_institutional_patient_search_test
 
       input :c4bb_v110_explanation_of_benefit_outpatient_institutional_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_outpatient_institutional_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_outpatient_institutional_service_date_search_test
 
       input :c4bb_v110_explanation_of_benefit_outpatient_institutional_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_outpatient_institutional_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_outpatient_institutional_type_search_test
 
       input :c4bb_v110_explanation_of_benefit_outpatient_institutional_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_outpatient_institutional_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       id :c4bb_v110_explanation_of_benefit_pharmacy__id_search_test
 
       input :c4bb_v110_explanation_of_benefit_pharmacy__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_pharmacy__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_pharmacy_identifier_search_test
 
       input :c4bb_v110_explanation_of_benefit_pharmacy_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_pharmacy_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_pharmacy__lastUpdated_search_test
 
       input :c4bb_v110_explanation_of_benefit_pharmacy__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_pharmacy__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_pharmacy_patient_search_test
 
       input :c4bb_v110_explanation_of_benefit_pharmacy_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_pharmacy_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_pharmacy_service_date_search_test
 
       input :c4bb_v110_explanation_of_benefit_pharmacy_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_pharmacy_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_pharmacy_type_search_test
 
       input :c4bb_v110_explanation_of_benefit_pharmacy_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_pharmacy_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       id :c4bb_v110_explanation_of_benefit_professional_non_clinician__id_search_test
 
       input :c4bb_v110_explanation_of_benefit_professional_non_clinician__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_professional_non_clinician__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_professional_non_clinician_identifier_search_test
 
       input :c4bb_v110_explanation_of_benefit_professional_non_clinician_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_professional_non_clinician_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_professional_non_clinician__lastUpdated_search_test
 
       input :c4bb_v110_explanation_of_benefit_professional_non_clinician__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_professional_non_clinician__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_professional_non_clinician_patient_search_test
 
       input :c4bb_v110_explanation_of_benefit_professional_non_clinician_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_professional_non_clinician_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_professional_non_clinician_service_date_search_test
 
       input :c4bb_v110_explanation_of_benefit_professional_non_clinician_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_professional_non_clinician_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v110_explanation_of_benefit_professional_non_clinician_type_search_test
 
       input :c4bb_v110_explanation_of_benefit_professional_non_clinician_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v110_explanation_of_benefit_professional_non_clinician_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/patient/patient_read_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/patient/patient_read_test.rb
@@ -14,7 +14,8 @@ module CarinForBlueButtonTestKit
       input :patient_ids,
         title: "patient IDs",
         type: 'text',
-        description: "patient Resource ID"
+        description: "Comma separated list of patient IDs that in sum
+                          contain all MUST SUPPORT elements"
 
       input_order :url, :smart_credentials, :patient_ids
 

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/coverage/coverage_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/coverage/coverage_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_coverage__id_search_test
 
       input :c4bb_v200devnonfinancial_coverage__id_search_test_param,
-        title: 'Coverage search parameter for _id
-',
+        title: 'Coverage search parameter for _id',
         type: 'text',
-        description: 'Coverage search parameter: _id
-'
+        description: 'Coverage search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'Coverage',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'Coverage',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:coverage_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_coverage__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/coverage/coverage_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/coverage/coverage_lastupdated_search_test.rb
@@ -20,17 +20,15 @@ none are returned, the test is skipped.
       
 
       input :c4bb_v200devnonfinancial_coverage__lastUpdated_search_test_param,
-        title: 'Coverage search parameter for _lastUpdated
-',
+        title: 'Coverage search parameter for _lastUpdated',
         type: 'text',
-        description: 'Coverage search parameter: _lastUpdated
-',
+        description: 'Coverage search parameter: _lastUpdated',
         optional: true
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Coverage',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -41,9 +39,8 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:coverage_resources] ||= {}
       end
-
+      
       run do
-        
         skip_if c4bb_v200devnonfinancial_coverage__lastUpdated_search_test_param.blank?, 'Coverage search parameter for _lastUpdated not provided'
         
         run_search_test(c4bb_v200devnonfinancial_coverage__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit/explanation_of_benefit_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_inpatient_institutional_non_financial/explanation_of_benefit_inpatient_institutional_non_financial_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_inpatient_institutional_non_financial_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral/explanation_of_benefit_oral_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_oral_non_financial/explanation_of_benefit_oral_non_financial_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_oral_non_financial_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_outpatient_institutional_non_financial/explanation_of_benefit_outpatient_institutional_non_financial_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_outpatient_institutional_non_financial_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_pharmacy_non_financial/explanation_of_benefit_pharmacy_non_financial_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_pharmacy_non_financial_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_billable_period_start_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial__id_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_identifier_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial__lastUpdated_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_patient_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_service_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_service_start_date_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/explanation_of_benefit_professional_non_clinician_non_financial/explanation_of_benefit_professional_non_clinician_non_financial_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_type_search_test
 
       input :c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_non_financial_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_explanation_of_benefit_professional_non_clinician_non_financial_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/organization/organization_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/organization/organization_id_search_test.rb
@@ -27,18 +27,16 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_organization__id_search_test
 
       input :c4bb_v200devnonfinancial_organization__id_search_test_param,
-        title: 'Organization search parameter for _id
-',
+        title: 'Organization search parameter for _id',
         type: 'text',
-        description: 'Organization search parameter: _id
-'
+        description: 'Organization search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'Organization',
-        search_param_names: ['_id'],
-        test_post_search: true
+          resource_type: 'Organization',
+          search_param_names: ['_id'],
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:organization_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_organization__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/organization/organization_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/organization/organization_lastupdated_search_test.rb
@@ -21,17 +21,15 @@ none are returned, the test is skipped.
       
 
       input :c4bb_v200devnonfinancial_organization__lastUpdated_search_test_param,
-        title: 'Organization search parameter for _lastUpdated
-',
+        title: 'Organization search parameter for _lastUpdated',
         type: 'text',
-        description: 'Organization search parameter: _lastUpdated
-',
+        description: 'Organization search parameter: _lastUpdated',
         optional: true
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Organization',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -42,9 +40,8 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:organization_resources] ||= {}
       end
-
+      
       run do
-        
         skip_if c4bb_v200devnonfinancial_organization__lastUpdated_search_test_param.blank?, 'Organization search parameter for _lastUpdated not provided'
         
         run_search_test(c4bb_v200devnonfinancial_organization__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient/patient_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient/patient_id_search_test.rb
@@ -26,19 +26,18 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
 
       id :c4bb_v200devnonfinancial_patient__id_search_test
 
-      input :c4bb_v200devnonfinancial_patient__id_search_test_param,
-        title: 'Patient search parameter for _id
-',
+      input :patient_ids,
+        title: 'Patient IDs',
         type: 'text',
-        description: 'Patient search parameter: _id
-'
+        description: 'Comma separated list of patient IDs that in sum
+                          contain all MUST SUPPORT elements'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'Patient',
-        search_param_names: ['_id'],
-        test_post_search: true
+          resource_type: 'Patient',
+          search_param_names: ['_id'],
+          test_post_search: true
         )
       end
 
@@ -49,10 +48,15 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:patient_resources] ||= {}
       end
-
+      
+      def patient_id_list
+        return [nil] unless respond_to? :patient_ids
+        patient_ids.split(',').map(&:strip)
+      end
+      
       run do
         
-        run_search_test(c4bb_v200devnonfinancial_patient__id_search_test_param)
+        run_search_test(patient_id_list)
       end
     end
   end

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient/patient_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient/patient_lastupdated_search_test.rb
@@ -21,17 +21,15 @@ none are returned, the test is skipped.
       
 
       input :c4bb_v200devnonfinancial_patient__lastUpdated_search_test_param,
-        title: 'Patient search parameter for _lastUpdated
-',
+        title: 'Patient search parameter for _lastUpdated',
         type: 'text',
-        description: 'Patient search parameter: _lastUpdated
-',
+        description: 'Patient search parameter: _lastUpdated',
         optional: true
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Patient',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -42,9 +40,8 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:patient_resources] ||= {}
       end
-
+      
       run do
-        
         skip_if c4bb_v200devnonfinancial_patient__lastUpdated_search_test_param.blank?, 'Patient search parameter for _lastUpdated not provided'
         
         run_search_test(c4bb_v200devnonfinancial_patient__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient/patient_read_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient/patient_read_test.rb
@@ -14,7 +14,8 @@ module CarinForBlueButtonTestKit
       input :patient_ids,
         title: "patient IDs",
         type: 'text',
-        description: "patient Resource ID"
+        description: "Comma separated list of patient IDs that in sum
+                          contain all MUST SUPPORT elements"
 
       input_order :url, :smart_credentials, :patient_ids
 

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/practitioner/practitioner_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/practitioner/practitioner_id_search_test.rb
@@ -27,18 +27,16 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_practitioner__id_search_test
 
       input :c4bb_v200devnonfinancial_practitioner__id_search_test_param,
-        title: 'Practitioner search parameter for _id
-',
+        title: 'Practitioner search parameter for _id',
         type: 'text',
-        description: 'Practitioner search parameter: _id
-'
+        description: 'Practitioner search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'Practitioner',
-        search_param_names: ['_id'],
-        test_post_search: true
+          resource_type: 'Practitioner',
+          search_param_names: ['_id'],
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:practitioner_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_practitioner__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/practitioner/practitioner_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/practitioner/practitioner_lastupdated_search_test.rb
@@ -21,17 +21,15 @@ none are returned, the test is skipped.
       
 
       input :c4bb_v200devnonfinancial_practitioner__lastUpdated_search_test_param,
-        title: 'Practitioner search parameter for _lastUpdated
-',
+        title: 'Practitioner search parameter for _lastUpdated',
         type: 'text',
-        description: 'Practitioner search parameter: _lastUpdated
-',
+        description: 'Practitioner search parameter: _lastUpdated',
         optional: true
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Practitioner',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -42,9 +40,8 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:practitioner_resources] ||= {}
       end
-
+      
       run do
-        
         skip_if c4bb_v200devnonfinancial_practitioner__lastUpdated_search_test_param.blank?, 'Practitioner search parameter for _lastUpdated not provided'
         
         run_search_test(c4bb_v200devnonfinancial_practitioner__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/related_person/related_person_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/related_person/related_person_id_search_test.rb
@@ -27,18 +27,16 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       id :c4bb_v200devnonfinancial_related_person__id_search_test
 
       input :c4bb_v200devnonfinancial_related_person__id_search_test_param,
-        title: 'RelatedPerson search parameter for _id
-',
+        title: 'RelatedPerson search parameter for _id',
         type: 'text',
-        description: 'RelatedPerson search parameter: _id
-'
+        description: 'RelatedPerson search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'RelatedPerson',
-        search_param_names: ['_id'],
-        test_post_search: true
+          resource_type: 'RelatedPerson',
+          search_param_names: ['_id'],
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       def scratch_resources
         scratch[:related_person_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200devnonfinancial_related_person__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/related_person/related_person_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/related_person/related_person_lastupdated_search_test.rb
@@ -21,17 +21,15 @@ none are returned, the test is skipped.
       
 
       input :c4bb_v200devnonfinancial_related_person__lastUpdated_search_test_param,
-        title: 'RelatedPerson search parameter for _lastUpdated
-',
+        title: 'RelatedPerson search parameter for _lastUpdated',
         type: 'text',
-        description: 'RelatedPerson search parameter: _lastUpdated
-',
+        description: 'RelatedPerson search parameter: _lastUpdated',
         optional: true
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'RelatedPerson',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -42,9 +40,8 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:related_person_resources] ||= {}
       end
-
+      
       run do
-        
         skip_if c4bb_v200devnonfinancial_related_person__lastUpdated_search_test_param.blank?, 'RelatedPerson search parameter for _lastUpdated not provided'
         
         run_search_test(c4bb_v200devnonfinancial_related_person__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/coverage/coverage_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/coverage/coverage_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       id :c4bb_v200_coverage__id_search_test
 
       input :c4bb_v200_coverage__id_search_test_param,
-        title: 'Coverage search parameter for _id
-',
+        title: 'Coverage search parameter for _id',
         type: 'text',
-        description: 'Coverage search parameter: _id
-'
+        description: 'Coverage search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'Coverage',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'Coverage',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:coverage_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_coverage__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/coverage/coverage_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/coverage/coverage_lastupdated_search_test.rb
@@ -20,17 +20,15 @@ none are returned, the test is skipped.
       
 
       input :c4bb_v200_coverage__lastUpdated_search_test_param,
-        title: 'Coverage search parameter for _lastUpdated
-',
+        title: 'Coverage search parameter for _lastUpdated',
         type: 'text',
-        description: 'Coverage search parameter: _lastUpdated
-',
+        description: 'Coverage search parameter: _lastUpdated',
         optional: true
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Coverage',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -41,9 +39,8 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:coverage_resources] ||= {}
       end
-
+      
       run do
-        
         skip_if c4bb_v200_coverage__lastUpdated_search_test_param.blank?, 'Coverage search parameter for _lastUpdated not provided'
         
         run_search_test(c4bb_v200_coverage__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_billable_period_start_search_test
 
       input :c4bb_v200_explanation_of_benefit_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       id :c4bb_v200_explanation_of_benefit__id_search_test
 
       input :c4bb_v200_explanation_of_benefit__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_identifier_search_test
 
       input :c4bb_v200_explanation_of_benefit_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit__lastUpdated_search_test
 
       input :c4bb_v200_explanation_of_benefit__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_patient_search_test
 
       input :c4bb_v200_explanation_of_benefit_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_service_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_service_start_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit/explanation_of_benefit_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_type_search_test
 
       input :c4bb_v200_explanation_of_benefit_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_inpatient_institutional_billable_period_start_search_test
 
       input :c4bb_v200_explanation_of_benefit_inpatient_institutional_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_inpatient_institutional_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       id :c4bb_v200_explanation_of_benefit_inpatient_institutional__id_search_test
 
       input :c4bb_v200_explanation_of_benefit_inpatient_institutional__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_inpatient_institutional__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_inpatient_institutional_identifier_search_test
 
       input :c4bb_v200_explanation_of_benefit_inpatient_institutional_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_inpatient_institutional_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_inpatient_institutional__lastUpdated_search_test
 
       input :c4bb_v200_explanation_of_benefit_inpatient_institutional__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_inpatient_institutional__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_inpatient_institutional_patient_search_test
 
       input :c4bb_v200_explanation_of_benefit_inpatient_institutional_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_inpatient_institutional_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_inpatient_institutional_service_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_inpatient_institutional_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_inpatient_institutional_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_inpatient_institutional_service_start_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_inpatient_institutional_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_inpatient_institutional_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_inpatient_institutional/explanation_of_benefit_inpatient_institutional_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_inpatient_institutional_type_search_test
 
       input :c4bb_v200_explanation_of_benefit_inpatient_institutional_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_inpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_inpatient_institutional_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_oral_billable_period_start_search_test
 
       input :c4bb_v200_explanation_of_benefit_oral_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_oral_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       id :c4bb_v200_explanation_of_benefit_oral__id_search_test
 
       input :c4bb_v200_explanation_of_benefit_oral__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_oral__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_oral_identifier_search_test
 
       input :c4bb_v200_explanation_of_benefit_oral_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_oral_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_oral__lastUpdated_search_test
 
       input :c4bb_v200_explanation_of_benefit_oral__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_oral__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_oral_patient_search_test
 
       input :c4bb_v200_explanation_of_benefit_oral_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_oral_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_oral_service_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_oral_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_oral_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_oral_service_start_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_oral_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_oral_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_oral/explanation_of_benefit_oral_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_oral_type_search_test
 
       input :c4bb_v200_explanation_of_benefit_oral_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_oral_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_oral_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_outpatient_institutional_billable_period_start_search_test
 
       input :c4bb_v200_explanation_of_benefit_outpatient_institutional_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_outpatient_institutional_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       id :c4bb_v200_explanation_of_benefit_outpatient_institutional__id_search_test
 
       input :c4bb_v200_explanation_of_benefit_outpatient_institutional__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_outpatient_institutional__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_outpatient_institutional_identifier_search_test
 
       input :c4bb_v200_explanation_of_benefit_outpatient_institutional_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_outpatient_institutional_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_outpatient_institutional__lastUpdated_search_test
 
       input :c4bb_v200_explanation_of_benefit_outpatient_institutional__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_outpatient_institutional__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_outpatient_institutional_patient_search_test
 
       input :c4bb_v200_explanation_of_benefit_outpatient_institutional_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_outpatient_institutional_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_outpatient_institutional_service_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_outpatient_institutional_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_outpatient_institutional_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_outpatient_institutional_service_start_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_outpatient_institutional_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_outpatient_institutional_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_outpatient_institutional/explanation_of_benefit_outpatient_institutional_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_outpatient_institutional_type_search_test
 
       input :c4bb_v200_explanation_of_benefit_outpatient_institutional_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_outpatient_institutional_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_outpatient_institutional_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_pharmacy_billable_period_start_search_test
 
       input :c4bb_v200_explanation_of_benefit_pharmacy_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_pharmacy_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       id :c4bb_v200_explanation_of_benefit_pharmacy__id_search_test
 
       input :c4bb_v200_explanation_of_benefit_pharmacy__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_pharmacy__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_pharmacy_identifier_search_test
 
       input :c4bb_v200_explanation_of_benefit_pharmacy_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_pharmacy_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_pharmacy__lastUpdated_search_test
 
       input :c4bb_v200_explanation_of_benefit_pharmacy__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_pharmacy__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_pharmacy_patient_search_test
 
       input :c4bb_v200_explanation_of_benefit_pharmacy_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_pharmacy_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_pharmacy_service_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_pharmacy_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_pharmacy_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_pharmacy_service_start_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_pharmacy_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_pharmacy_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_pharmacy/explanation_of_benefit_pharmacy_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_pharmacy_type_search_test
 
       input :c4bb_v200_explanation_of_benefit_pharmacy_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_pharmacy_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_pharmacy_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_billable_period_start_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_billable_period_start_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_professional_non_clinician_billable_period_start_search_test
 
       input :c4bb_v200_explanation_of_benefit_professional_non_clinician_billable_period_start_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for billable-period-start
-',
+        title: 'ExplanationOfBenefit search parameter for billable-period-start',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: billable-period-start
-'
+        description: 'ExplanationOfBenefit search parameter: billable-period-start'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['billable-period-start']
+          search_param_names: ['billable-period-start']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_professional_non_clinician_billable_period_start_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_id_search_test.rb
@@ -26,19 +26,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       id :c4bb_v200_explanation_of_benefit_professional_non_clinician__id_search_test
 
       input :c4bb_v200_explanation_of_benefit_professional_non_clinician__id_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _id
-',
+        title: 'ExplanationOfBenefit search parameter for _id',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _id
-'
+        description: 'ExplanationOfBenefit search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_id'],
-        saves_delayed_references: true,
-        test_post_search: true
+          resource_type: 'ExplanationOfBenefit',
+          search_param_names: ['_id'],
+          saves_delayed_references: true,
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_professional_non_clinician__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_identifier_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_identifier_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_professional_non_clinician_identifier_search_test
 
       input :c4bb_v200_explanation_of_benefit_professional_non_clinician_identifier_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for identifier
-',
+        title: 'ExplanationOfBenefit search parameter for identifier',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: identifier
-'
+        description: 'ExplanationOfBenefit search parameter: identifier'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['identifier'],
-        token_search_params: ['identifier']
+          search_param_names: ['identifier'],
+          token_search_params: ['identifier']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_professional_non_clinician_identifier_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_lastupdated_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_professional_non_clinician__lastUpdated_search_test
 
       input :c4bb_v200_explanation_of_benefit_professional_non_clinician__lastUpdated_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for _lastUpdated
-',
+        title: 'ExplanationOfBenefit search parameter for _lastUpdated',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: _lastUpdated
-'
+        description: 'ExplanationOfBenefit search parameter: _lastUpdated'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_professional_non_clinician__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_patient_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_professional_non_clinician_patient_search_test
 
       input :c4bb_v200_explanation_of_benefit_professional_non_clinician_patient_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for patient
-',
+        title: 'ExplanationOfBenefit search parameter for patient',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: patient
-'
+        description: 'ExplanationOfBenefit search parameter: patient'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_professional_non_clinician_patient_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_service_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_service_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_professional_non_clinician_service_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_professional_non_clinician_service_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-date']
+          search_param_names: ['service-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_professional_non_clinician_service_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_service_start_date_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_service_start_date_search_test.rb
@@ -18,16 +18,14 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_professional_non_clinician_service_start_date_search_test
 
       input :c4bb_v200_explanation_of_benefit_professional_non_clinician_service_start_date_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for service-start-date
-',
+        title: 'ExplanationOfBenefit search parameter for service-start-date',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: service-start-date
-'
+        description: 'ExplanationOfBenefit search parameter: service-start-date'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['service-start-date']
+          search_param_names: ['service-start-date']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_professional_non_clinician_service_start_date_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_type_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/explanation_of_benefit_professional_non_clinician/explanation_of_benefit_professional_non_clinician_type_search_test.rb
@@ -18,17 +18,15 @@ none are returned, the test is skipped.
       id :c4bb_v200_explanation_of_benefit_professional_non_clinician_type_search_test
 
       input :c4bb_v200_explanation_of_benefit_professional_non_clinician_type_search_test_param,
-        title: 'ExplanationOfBenefit search parameter for type
-',
+        title: 'ExplanationOfBenefit search parameter for type',
         type: 'text',
-        description: 'ExplanationOfBenefit search parameter: type
-'
+        description: 'ExplanationOfBenefit search parameter: type'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['type'],
-        token_search_params: ['type']
+          search_param_names: ['type'],
+          token_search_params: ['type']
         )
       end
 
@@ -39,7 +37,7 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:explanation_of_benefit_professional_non_clinician_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_explanation_of_benefit_professional_non_clinician_type_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/organization/organization_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/organization/organization_id_search_test.rb
@@ -27,18 +27,16 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       id :c4bb_v200_organization__id_search_test
 
       input :c4bb_v200_organization__id_search_test_param,
-        title: 'Organization search parameter for _id
-',
+        title: 'Organization search parameter for _id',
         type: 'text',
-        description: 'Organization search parameter: _id
-'
+        description: 'Organization search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'Organization',
-        search_param_names: ['_id'],
-        test_post_search: true
+          resource_type: 'Organization',
+          search_param_names: ['_id'],
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:organization_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_organization__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/organization/organization_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/organization/organization_lastupdated_search_test.rb
@@ -21,17 +21,15 @@ none are returned, the test is skipped.
       
 
       input :c4bb_v200_organization__lastUpdated_search_test_param,
-        title: 'Organization search parameter for _lastUpdated
-',
+        title: 'Organization search parameter for _lastUpdated',
         type: 'text',
-        description: 'Organization search parameter: _lastUpdated
-',
+        description: 'Organization search parameter: _lastUpdated',
         optional: true
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Organization',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -42,9 +40,8 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:organization_resources] ||= {}
       end
-
+      
       run do
-        
         skip_if c4bb_v200_organization__lastUpdated_search_test_param.blank?, 'Organization search parameter for _lastUpdated not provided'
         
         run_search_test(c4bb_v200_organization__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient/patient_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient/patient_id_search_test.rb
@@ -26,19 +26,18 @@ requirement of CARIN IG for Blue Button® v2.0.0.
 
       id :c4bb_v200_patient__id_search_test
 
-      input :c4bb_v200_patient__id_search_test_param,
-        title: 'Patient search parameter for _id
-',
+      input :patient_ids,
+        title: 'Patient IDs',
         type: 'text',
-        description: 'Patient search parameter: _id
-'
+        description: 'Comma separated list of patient IDs that in sum
+                          contain all MUST SUPPORT elements'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'Patient',
-        search_param_names: ['_id'],
-        test_post_search: true
+          resource_type: 'Patient',
+          search_param_names: ['_id'],
+          test_post_search: true
         )
       end
 
@@ -49,10 +48,15 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:patient_resources] ||= {}
       end
-
+      
+      def patient_id_list
+        return [nil] unless respond_to? :patient_ids
+        patient_ids.split(',').map(&:strip)
+      end
+      
       run do
         
-        run_search_test(c4bb_v200_patient__id_search_test_param)
+        run_search_test(patient_id_list)
       end
     end
   end

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient/patient_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient/patient_lastupdated_search_test.rb
@@ -21,17 +21,15 @@ none are returned, the test is skipped.
       
 
       input :c4bb_v200_patient__lastUpdated_search_test_param,
-        title: 'Patient search parameter for _lastUpdated
-',
+        title: 'Patient search parameter for _lastUpdated',
         type: 'text',
-        description: 'Patient search parameter: _lastUpdated
-',
+        description: 'Patient search parameter: _lastUpdated',
         optional: true
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Patient',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -42,9 +40,8 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:patient_resources] ||= {}
       end
-
+      
       run do
-        
         skip_if c4bb_v200_patient__lastUpdated_search_test_param.blank?, 'Patient search parameter for _lastUpdated not provided'
         
         run_search_test(c4bb_v200_patient__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient/patient_read_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient/patient_read_test.rb
@@ -14,7 +14,8 @@ module CarinForBlueButtonTestKit
       input :patient_ids,
         title: "patient IDs",
         type: 'text',
-        description: "patient Resource ID"
+        description: "Comma separated list of patient IDs that in sum
+                          contain all MUST SUPPORT elements"
 
       input_order :url, :smart_credentials, :patient_ids
 

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/practitioner/practitioner_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/practitioner/practitioner_id_search_test.rb
@@ -27,18 +27,16 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       id :c4bb_v200_practitioner__id_search_test
 
       input :c4bb_v200_practitioner__id_search_test_param,
-        title: 'Practitioner search parameter for _id
-',
+        title: 'Practitioner search parameter for _id',
         type: 'text',
-        description: 'Practitioner search parameter: _id
-'
+        description: 'Practitioner search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'Practitioner',
-        search_param_names: ['_id'],
-        test_post_search: true
+          resource_type: 'Practitioner',
+          search_param_names: ['_id'],
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:practitioner_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_practitioner__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/practitioner/practitioner_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/practitioner/practitioner_lastupdated_search_test.rb
@@ -21,17 +21,15 @@ none are returned, the test is skipped.
       
 
       input :c4bb_v200_practitioner__lastUpdated_search_test_param,
-        title: 'Practitioner search parameter for _lastUpdated
-',
+        title: 'Practitioner search parameter for _lastUpdated',
         type: 'text',
-        description: 'Practitioner search parameter: _lastUpdated
-',
+        description: 'Practitioner search parameter: _lastUpdated',
         optional: true
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Practitioner',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -42,9 +40,8 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:practitioner_resources] ||= {}
       end
-
+      
       run do
-        
         skip_if c4bb_v200_practitioner__lastUpdated_search_test_param.blank?, 'Practitioner search parameter for _lastUpdated not provided'
         
         run_search_test(c4bb_v200_practitioner__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/related_person/related_person_id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/related_person/related_person_id_search_test.rb
@@ -27,18 +27,16 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       id :c4bb_v200_related_person__id_search_test
 
       input :c4bb_v200_related_person__id_search_test_param,
-        title: 'RelatedPerson search parameter for _id
-',
+        title: 'RelatedPerson search parameter for _id',
         type: 'text',
-        description: 'RelatedPerson search parameter: _id
-'
+        description: 'RelatedPerson search parameter: _id'
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           first_search: true,
-        resource_type: 'RelatedPerson',
-        search_param_names: ['_id'],
-        test_post_search: true
+          resource_type: 'RelatedPerson',
+          search_param_names: ['_id'],
+          test_post_search: true
         )
       end
 
@@ -49,7 +47,7 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       def scratch_resources
         scratch[:related_person_resources] ||= {}
       end
-
+      
       run do
         
         run_search_test(c4bb_v200_related_person__id_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/related_person/related_person_lastupdated_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/related_person/related_person_lastupdated_search_test.rb
@@ -21,17 +21,15 @@ none are returned, the test is skipped.
       
 
       input :c4bb_v200_related_person__lastUpdated_search_test_param,
-        title: 'RelatedPerson search parameter for _lastUpdated
-',
+        title: 'RelatedPerson search parameter for _lastUpdated',
         type: 'text',
-        description: 'RelatedPerson search parameter: _lastUpdated
-',
+        description: 'RelatedPerson search parameter: _lastUpdated',
         optional: true
 
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'RelatedPerson',
-        search_param_names: ['_lastUpdated']
+          search_param_names: ['_lastUpdated']
         )
       end
 
@@ -42,9 +40,8 @@ none are returned, the test is skipped.
       def scratch_resources
         scratch[:related_person_resources] ||= {}
       end
-
+      
       run do
-        
         skip_if c4bb_v200_related_person__lastUpdated_search_test_param.blank?, 'RelatedPerson search parameter for _lastUpdated not provided'
         
         run_search_test(c4bb_v200_related_person__lastUpdated_search_test_param)

--- a/lib/carin_for_blue_button_test_kit/generator/read_test_generator.rb
+++ b/lib/carin_for_blue_button_test_kit/generator/read_test_generator.rb
@@ -114,6 +114,20 @@ module CarinForBlueButtonTestKit
           file_name: base_output_file_name
         )
       end
+
+      def input_description
+        desc_content =  if profile_identifier == 'patient'
+                          "
+                          Comma separated list of patient IDs that in sum
+                          contain all MUST SUPPORT elements
+                          "
+                        else
+                          "#{profile_identifier} Resource ID"
+                        end
+        <<~INPUT_DESCRIPTION
+        #{desc_content}
+        INPUT_DESCRIPTION
+      end
     end
   end
 end

--- a/lib/carin_for_blue_button_test_kit/generator/search_test_generator.rb
+++ b/lib/carin_for_blue_button_test_kit/generator/search_test_generator.rb
@@ -11,7 +11,9 @@ module CarinForBlueButtonTestKit
             .select { |group| group.searches.present? }
             .each do |group|
               group.searches.each { |search| new(group, search, base_output_dir).generate }
-              group.include_params.each{ |param| IncludeSearchTestGenerator.new(group, param, base_output_dir).generate }
+              group.include_params.each do |param|
+ IncludeSearchTestGenerator.new(group, param, base_output_dir).generate
+              end
             end
         end
       end
@@ -208,7 +210,10 @@ module CarinForBlueButtonTestKit
           properties[:token_search_params] = token_search_params_string if token_search_params.present?
           properties[:test_reference_variants] = 'true' if test_reference_variants?
           properties[:params_with_comparators] = required_comparators_string if required_comparators.present?
-          properties[:multiple_or_search_params] = required_multiple_or_search_params_string if required_multiple_or_search_params.present?
+          if required_multiple_or_search_params.present?
+            properties[:multiple_or_search_params] = 
+              required_multiple_or_search_params_string
+          end
           properties[:test_post_search] = 'true' if first_search?
         end
       end
@@ -230,7 +235,7 @@ module CarinForBlueButtonTestKit
 
       def generate
         FileUtils.mkdir_p(output_file_directory)
-        File.open(output_file_name, 'w') { |f| f.write(output) }
+        File.write(output_file_name, output)
 
         group_metadata.add_test(
           id: test_id,
@@ -282,15 +287,38 @@ module CarinForBlueButtonTestKit
         DESCRIPTION
       end
 
+      def patient_id_param?
+        resource_type == 'Patient' && search_param_name_string == '_id'
+      end
+
+      def input_id
+        patient_id_param? ? "patient_ids" : "#{test_id}_param"
+      end
+
       def input_title
+        title_content = if patient_id_param?
+                          "Patient IDs"
+                        else
+                          "#{resource_type} search parameter for #{search_param_name_string}"
+                        end
+
         <<~INPUT_TITLE
-        #{resource_type} search parameter for #{search_param_name_string}
+        #{title_content.strip}
         INPUT_TITLE
       end
 
+
       def input_description
+        desc_content =  if patient_id_param?
+                          "
+                          Comma separated list of patient IDs that in sum
+                          contain all MUST SUPPORT elements
+                          "
+                        else
+                          "#{resource_type} search parameter: #{search_param_name_string}"
+                        end
         <<~INPUT_DESCRIPTION
-        #{resource_type} search parameter: #{search_param_name_string}
+        #{desc_content}
         INPUT_DESCRIPTION
       end
     end

--- a/lib/carin_for_blue_button_test_kit/generator/templates/read.rb.erb
+++ b/lib/carin_for_blue_button_test_kit/generator/templates/read.rb.erb
@@ -14,7 +14,7 @@ module CarinForBlueButtonTestKit
       input :<%= profile_identifier %>_ids,
         title: "<%= profile_identifier %> IDs",
         type: 'text',
-        description: "<%= profile_identifier %> Resource ID"
+        description: "<%= input_description.strip %>"
 
       input_order :url, :smart_credentials, :<%= profile_identifier %>_ids
 

--- a/lib/carin_for_blue_button_test_kit/generator/templates/search.rb.erb
+++ b/lib/carin_for_blue_button_test_kit/generator/templates/search.rb.erb
@@ -15,15 +15,15 @@ module CarinForBlueButtonTestKit
       optional
       <% end %>
 
-      input :<%=test_id%>_param,
-        title: '<%=input_title%>',
+      input :<%=input_id%>,
+        title: '<%=input_title.strip%>',
         type: 'text',
-        description: '<%=input_description%>'<%if optional?%>,
+        description: '<%=input_description.strip%>'<%if optional?%>,
         optional: true<% end %>
 
       def self.properties
         @properties ||= SearchTestProperties.new(
-  <%= search_test_properties_string %>
+  <%= search_test_properties_string.gsub("\n", "\n" + " "*2) %>
         )
       end
 
@@ -34,12 +34,16 @@ module CarinForBlueButtonTestKit
       def scratch_resources
         scratch[:<%= profile_identifier %>_resources] ||= {}
       end
-
+      <% if patient_id_param? %>
+      def patient_id_list
+        return [nil] unless respond_to? :patient_ids
+        patient_ids.split(',').map(&:strip)
+      end
+      <% end %>
       run do
-        <% if optional? %>
-        skip_if <%=test_id%>_param.blank?, '<%="#{input_title.chop!} not provided" %>'
+        <% if optional? %>skip_if <%=input_id%>.blank?, '<%="#{input_title.chop!} not provided" %>'
         <% end %>
-        run_search_test(<%=test_id%>_param)
+        run_search_test(<%= patient_id_param? ? "patient_id_list" : input_id%>)
       end
     end
   end


### PR DESCRIPTION
# Summary
This PR fixes the Patient search by _id  to properly lookup resources when multiple patient ids (e.g. patient1,patient2) are provided as a comma separated string list. It enables the test kit to make multiple request: `http://example.com/fhir/Patient?_id=patient1, http://example.com/fhir/Patient?_id=patient2` when  `patient1, patient2` is provided as `patient_ids` input, and ensures that at least one returned resource successfully validates.
The `patient_ids` input  has also been standardized to be used as input for patient search by _id test as opposed to use different input name for search by _id test and read test. This ensures that the user only has to provide that input once.

# Files Changed
The main files edited are : 
- **search_test_generator.rb**: 
  - Added `input_id` method that defines the search test input name based on wether the search param is _id and resource is patient .  This ensures that the Patient search by _id  test input has the same name as the patient read test input .
  - Updated the `input_title` and `input_description` methods accordingly
- **search.rb.erb**: 
  -  Added the `patient_id_list` method to the template to properly format the provided patient_ids input for _id search test before the suite can make a request.
- **carin_search_test.rb**:  
  - Added a fix to send multiple requests and properly handle validation of the patient  _id search test result when multiple ids are provided 
- you **carin_searn_test_spec.rb**: 
   - Updated spec to test _id search test for multiple ids.
   
# Testing Guidance
Run the unit test & ensure everything passes.

Web Testing: was tested using a local instance of the [C4BB RI](https://github.com/vanessuniq/cpcds-server-ri)

