### PR TITLE
Add .gitattributes file to mark generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+lib/carin_for_blue_button_test_kit/generated/** linguist-generated=true


### PR DESCRIPTION
This branch adds a `.gitattributes` file which indicates that the `generated` folder is generated so that github will automatically collapse the diffs for those files.