### PR TITLE
FI-2429: Additional changes for HL7 validator transition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     carin_for_blue_button_test_kit (0.11.0)
-      inferno_core (~> 0.4.2)
+      inferno_core (~> 0.4.37)
       smart_app_launch_test_kit (~> 0.4)
 
 GEM

--- a/carin_for_blue_button_test_kit.gemspec
+++ b/carin_for_blue_button_test_kit.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'CARIN IG for Blue Button® Test Kit'
   spec.homepage      = 'https://github.com/inferno-framework/carin-for-blue-button-test-kit'
   spec.license       = 'Apache-2.0'
-  spec.add_runtime_dependency 'inferno_core', '~> 0.4.2'
+  spec.add_runtime_dependency 'inferno_core', '~> 0.4.37'
   spec.add_runtime_dependency 'smart_app_launch_test_kit', '~> 0.4'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'

--- a/lib/carin_for_blue_button_test_kit/igs/README.md
+++ b/lib/carin_for_blue_button_test_kit/igs/README.md
@@ -1,0 +1,21 @@
+# Note on this IGs folder
+
+There are three reasons why it would be necessary to put an IG package.tgz in this folder. If none of these apply, you do not need to put any files here, or can consider removing any existing files to make it clear they are unused.
+
+## 1. Generated Test Suites
+Some test kits use a "generator" to automatically generate the contents of a test suite for an IG. The IG files are required every time the test suites need to be regenerated. Examples of test kits that use this approach are the US Core Test Kit and CARIN IG for Blue Button® Test Kit.
+
+
+## 2. Non-published IG
+If your IG, or the specific version of the IG you want to test against, is not published, then the validator service needs to load the IG from file in order to be able to validate resources with it. The IG must be referenced in the `fhir_resource_validator` block in the test suite definition by filename, ie:
+
+```ruby
+      fhir_resource_validator do
+        igs 'igs/filename.tgz'
+
+        ...
+      end
+```
+
+## 3. Inferno Validator UI
+The Inferno Validator UI is configured to auto-load any IGs present in the igs folder and include them in all validations. The Inferno Validator UI is currently disabled by default, so this is only relevant if you choose to re-enable it. In general, the Inferno team is currently leaving IGs in this folder even if not otherwise necessary to make it easy to re-enable the validator UI.

--- a/lib/carin_for_blue_button_test_kit/igs/README.md
+++ b/lib/carin_for_blue_button_test_kit/igs/README.md
@@ -1,13 +1,13 @@
 # Note on this IGs folder
 
-There are three reasons why it would be necessary to put an IG package.tgz in this folder. If none of these apply, you do not need to put any files here, or can consider removing any existing files to make it clear they are unused.
+There are three reasons why it might be necessary to put an IG package.tgz in this folder. If none of these apply, you do not need to put any files here, or can consider removing any existing files to make it clear they are unused.
 
 ## 1. Generated Test Suites
 Some test kits use a "generator" to automatically generate the contents of a test suite for an IG. The IG files are required every time the test suites need to be regenerated. Examples of test kits that use this approach are the US Core Test Kit and CARIN IG for Blue Button® Test Kit.
 
 
 ## 2. Non-published IG
-If your IG, or the specific version of the IG you want to test against, is not published, then the validator service needs to load the IG from file in order to be able to validate resources with it. The IG must be referenced in the `fhir_resource_validator` block in the test suite definition by filename, ie:
+If your IG, or the specific version of the IG you want to test against, is not published, the validator service needs to load the IG from file to validate resources with it. The IG must be referenced in the `fhir_resource_validator` block in the test suite definition by filename, ie.:
 
 ```ruby
       fhir_resource_validator do


### PR DESCRIPTION
# Summary
Two additional changes for the HL7 validator wrapper transition that we identified elsewhere after the first PR here had already been merged:
- Bumps the core dependency in the gemspec to a version that supports the HL7 wrapper (specifically, 0.4.37, the latest version as of today)
- Adds a README to the igs folder explaining when it's necessary for the package tgzs to be present