### PR TITLE
FI-3355: Integrate Carin Client Test Suite with Reference Client

### DIFF
--- a/config/presets/carin_cpcds_client_ri.json
+++ b/config/presets/carin_cpcds_client_ri.json
@@ -1,0 +1,12 @@
+{
+  "title": "Carin CPCDS Reference Implementation Client",
+  "id": "carin_cpcds_client_ri_preset",
+  "test_suite_id": "c4bb_v200_client",
+  "inputs": [
+    {
+      "name": "access_token",
+      "type": "text",
+      "value": "SAMPLE_TOKEN"
+    }
+  ]
+}

--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/c4bb_client_test_suite.rb
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/c4bb_client_test_suite.rb
@@ -2,6 +2,7 @@ require 'inferno/dsl/oauth_credentials'
 require_relative 'endpoints/submit_claims_endpoint'
 require_relative 'endpoints/token_endpoint'
 require_relative 'endpoints/next_page_endpoint'
+require_relative 'endpoints/resource_id_endpoint'
 
 require_relative 'urls'
 require_relative 'mock_server'
@@ -76,6 +77,8 @@ module CarinForBlueButtonTestKit
     suite_endpoint :get, PATIENT_PATH, SubmitClaimsEndpoint
 
     suite_endpoint :get, SUBMIT_PATH, SubmitClaimsEndpoint
+
+    suite_endpoint :get, RESOURCE_ID_PATH, ResourceIDEndpoint
 
     suite_endpoint :get, BASE_FHIR_PATH, NextPageEndpoint
 

--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/claim_data_request_tests/initial_wait_test.rb
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/claim_data_request_tests/initial_wait_test.rb
@@ -21,7 +21,7 @@ module CarinForBlueButtonTestKit
           to reach and `:search_params` replaced with the search parameters for the request.
 
           The following Carin resources can be accessed on the Inferno Reference Server with the following IDs:
-            * Patient: `998`
+            * Patient: `888`
             * Coverage: `c4bb-Coverage`
             * Organization: `c4bb-Organization`
             * Practitioner: `c4bb-Practitioner`

--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/claim_data_request_tests/patient_claims_data_request_test.rb
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/claim_data_request_tests/patient_claims_data_request_test.rb
@@ -16,7 +16,7 @@ module CarinForBlueButtonTestKit
     run do
       skip_if scratch[:Patient].nil?, 'No requests made for Patient resources'
 
-      assert scratch[:Patient].any? { |resource| resource.id == '998' }, 'Unable to find expected resource: 998'
+      assert scratch[:Patient].any? { |resource| resource.id == '888' }, 'Unable to find expected resource: 888'
     end
   end
 end

--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/collection.rb
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/collection.rb
@@ -3,14 +3,14 @@ module CarinForBlueButtonTestKit
                          ExplanationOfBenefit: ['c4bb-EOBInpatient', 'c4bb-EOBOral', 'c4bb-EOBOutpatient',
                                                 'c4bb-EOBPharmacy', 'c4bb-EOBProfessional'],
                          Organization: ['c4bb-Organization'],
-                         Patient: ['998'],
+                         Patient: ['888'],
                          Practitioner: ['c4bb-Practitioner'],
                          RelatedPerson: ['c4bb-RelatedPerson'] }.freeze
 
   SEARCHES_BY_PRIORITY = { Coverage: [['_id'], ['_lastUpdated']],
                            ExplanationOfBenefit: [['_id'], ['patient'], ['identifier'], ['_lastUpdated'],
                                                   ['service-date'], ['service-start-date'], ['billable-period-start'],
-                                                  ['type']],
+                                                  ['type'], ['_include']],
                            Organization: [['_id'], ['_lastUpdated']],
                            Patient: [['_id'], ['_lastUpdated']],
                            Practitioner: [['_id'], ['_lastUpdated']],

--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/endpoints/resource_id_endpoint.rb
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/endpoints/resource_id_endpoint.rb
@@ -1,0 +1,24 @@
+require_relative '../tags'
+require_relative '../mock_server'
+
+module CarinForBlueButtonTestKit
+  class ResourceIDEndpoint < Inferno::DSL::SuiteEndpoint
+    include CarinForBlueButtonTestKit::MockServer
+
+    def test_run_identifier
+      extract_bearer_token(request)
+    end
+
+    def make_response
+      carin_resource_id_response(request)
+    end
+
+    def tags
+      [RESOURCE_ID_TAG]
+    end
+
+    def update_result
+      results_repo.update(result.id, result: 'pass') unless test.config.options[:accepts_multiple_requests]
+    end
+  end
+end

--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/metadata/mock_capability_statement.json
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/metadata/mock_capability_statement.json
@@ -23,9 +23,6 @@
     {
       "mode": "server",
       "documentation": "The C4BB  Server **SHALL**:\n\n1. Support all profiles defined in this Implementation Guide..\n2.  Implement the RESTful behavior according to the FHIR specification.\n3. Return the following response classes:\n   - (Status 400): invalid parameter\n   - (Status 401/4xx): unauthorized request\n   - (Status 403): insufficient scope\n   - (Status 404): unknown resource\n   - (Status 410): deleted resource.\n4. Support json source formats for all CARIN-BB interactions.\n5. Identify the CARIN-BB  profiles supported as part of the FHIR `meta.profile` attribute for each instance.\n6. Support the searchParameters on each profile  individually and in combination.\n\nThe C4BB  Server **SHOULD**:\n\n1. Support xml source formats for all C4BB interactions.\n",
-      "security": {
-        "description": "1. See the [General Security Considerations](Security_And_Privacy_Considerations.html) section for requirements and recommendations.\n2. A server **SHALL** reject any unauthorized requests by returning an HTTP 401 \"Unauthorized\", HTTP 403 \"Forbidden\", or HTTP 404 \"Not Found\" ."
-      },
       "resource": [
         {
           "extension": [

--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/tags.rb
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/tags.rb
@@ -3,4 +3,5 @@
 module CarinForBlueButtonTestKit
   AUTH_TAG = 'carin_auth'
   SUBMIT_TAG = 'carin_submit'
+  RESOURCE_ID_TAG = 'carin_resource_id'
 end

--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/urls.rb
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/urls.rb
@@ -2,6 +2,7 @@ module CarinForBlueButtonTestKit
   TOKEN_PATH = '/mock_auth/token'
   PATIENT_PATH = '/fhir/Patient'
   SUBMIT_PATH = '/fhir/:endpoint'
+  RESOURCE_ID_PATH = '/fhir/:endpoint/:id'
   METADATA_PATH = '/fhir/metadata'
   BASE_FHIR_PATH = '/fhir'
   RESUME_PASS_PATH = '/resume_pass'
@@ -27,6 +28,10 @@ module CarinForBlueButtonTestKit
 
     def submit_url
       @submit_url ||= base_url + SUBMIT_PATH
+    end
+
+    def resource_id_url
+      @resource_id_url ||= base_url + RESOURCE_ID_PATH
     end
 
     def metadata_url


### PR DESCRIPTION
# Summary
Updated the Carin Client Suite to work with [cpcds Reference Client]( https://github.com/carin-alliance/cpcds-client-ri). Changes include:
2. Adding `_include` search support for the ExplanationOfBenefit resource
3. Allowing the stringing of multiple of the same parameters, such as multiple`_include` params for ExplanationOfBenefit
4. Adding support for `/fhir/:endpoint/:id` queries
5. Removing `security` field from mock capability statement

Also, changed Carin patient id from `998` to `888` since patient 998 already exists on the reference server to avoid confusion. Fixed up some minor path errors as well for the mock capability and operation outcome resources.

# Testing Guidance
To test, you need to run this test kit locally with the CPCDS Reference Implementation Client preset. Then you must run the reference server locally with this Bundle put in the `resources` folder: 
[carin_bundle_patient_888.json](https://github.com/user-attachments/files/17603932/carin_bundle_patient_888.json)

Finally, run the cpcds client on this forked repo branch: https://github.com/emichaud998/cpcds-client-ri/tree/Inferno_C4BB_Client_Test_Kit

Notes about running cpcds client:

- I had Java 18 installed, but this required that I downgraded to 17
- I installed `rails` with the command: `gem install rails`, and then had to run any of the rails commands in the read me by prepending it with `bundle exec rails`
- When running the client, navigate to localhost:3000, and then type in the running Carin Client suite FHIR endpoint, and type the Carin patient id, `888`, into the client secret and client id fields. Then hit the `Display` button on the next page and it will make a request to the Carin Client suite. Then click the link in the Inferno Carin Client Test Suite dialog to say you have finished submitting requests. If you hit true for the next attestation test that pops up, all the tests should pass.
 
