### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.12.0
+
+* FI-3086: Add the Ability to Map Requirements to Test into the CARIN Test Kit by @emichaud998 in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/46
+* FI-3410: Update inferno core requirement by @Jammjammjamm in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/49
+
 # 0.11.2
 
 * Dependency Updates 2024-07-03 by @Jammjammjamm in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/42

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    carin_for_blue_button_test_kit (0.11.2)
+    carin_for_blue_button_test_kit (0.12.0)
       inferno_core (~> 0.5.0)
       roo (~> 2.7.1)
       smart_app_launch_test_kit (~> 0.4)
@@ -183,7 +183,7 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1001)
+    mime-types-data (3.2024.1105)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
     multi_json (1.15.0)
@@ -266,7 +266,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
-    smart_app_launch_test_kit (0.4.3)
+    smart_app_launch_test_kit (0.4.6)
       inferno_core (>= 0.4.2)
       json-jwt (~> 1.15.3)
       jwt (~> 2.6)
@@ -284,7 +284,7 @@ GEM
     strings-ansi (0.2.0)
     thor (1.2.2)
     tilt (2.4.0)
-    tls_test_kit (0.2.2)
+    tls_test_kit (0.2.3)
       inferno_core (>= 0.4.2)
     tty-color (0.6.0)
     tty-markdown (0.7.2)

--- a/lib/carin_for_blue_button_test_kit/version.rb
+++ b/lib/carin_for_blue_button_test_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CarinForBlueButtonTestKit
-  VERSION = '0.11.2'
+  VERSION = '0.12.0'
 end


### PR DESCRIPTION
## What's Changed
* FI-3086: Add the Ability to Map Requirements to Test into the CARIN Test Kit by @emichaud998 in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/46
* FI-3410: Update inferno core requirement by @Jammjammjamm in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/49
