### PR TITLE
move roo to a development dependency in the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gemspec
 group :development, :test do
   gem 'debug'
   gem 'foreman'
+  gem 'roo', '~> 2.7.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     carin_for_blue_button_test_kit (0.12.0)
       inferno_core (~> 0.5.0)
-      roo (~> 2.7.1)
       smart_app_launch_test_kit (~> 0.4)
 
 GEM
@@ -318,6 +317,7 @@ DEPENDENCIES
   debug
   factory_bot (~> 6.1)
   foreman
+  roo (~> 2.7.1)
   rspec (~> 3.10)
   webmock (~> 3.11)
 

--- a/carin_for_blue_button_test_kit.gemspec
+++ b/carin_for_blue_button_test_kit.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'factory_bot', '~> 6.1'
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'webmock', '~> 3.11'
-  spec.add_dependency 'roo', '~> 2.7.1'
   spec.required_ruby_version = Gem::Requirement.new('>= 3.1.2')
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/inferno-framework/carin-for-blue-button-test-kit'


### PR DESCRIPTION
# Summary

move roo dependency for requirements tooling from a gemspec dependency to a development dependency in the gemfile

