### PR TITLE
Fix: Made Carin Wait Test ID Unique

### DIFF
--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/c4bb_client_test_suite.rb
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/c4bb_client_test_suite.rb
@@ -112,7 +112,7 @@ module CarinForBlueButtonTestKit
         [US Core Client CapabilityStatement](https://hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-client.html).
       )
 
-      test from: :initial_wait_test
+      test from: :c4bb_v200_initial_wait_test
     end
 
     group do

--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/initial_wait_test.rb
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/initial_wait_test.rb
@@ -3,7 +3,7 @@ module CarinForBlueButtonTestKit
   class C4BBClientInitialWaitTest < Inferno::Test
     include URLs
 
-    id :initial_wait_test
+    id :c4bb_v200_initial_wait_test
     title 'Client makes claims data and required search parameter requests'
     description %(
       This test will receive claims data requests and search requests until the user confirms they are done.


### PR DESCRIPTION
# Summary

This PR ensure that carin bb wait test has a unique id

