### PR TITLE
Endpoint Suite ID Fix

### DIFF
--- a/lib/carin_for_blue_button_test_kit/client/v2.0.0/urls.rb
+++ b/lib/carin_for_blue_button_test_kit/client/v2.0.0/urls.rb
@@ -51,7 +51,7 @@ module CarinForBlueButtonTestKit
     end
 
     def suite_id
-      self.class.suite.id
+      CarinForBlueButtonTestKit::C4BBV200ClientSuite.id
     end
   end
 end


### PR DESCRIPTION
# Summary
Fix how suite id is determined when creating endpoint paths so that the endpoints defined in this test kit can be reused by other test kits.

# Testing Guidance
Make sure everything still works as expected in this test kit
