### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.14.0
+
+* **Ruby Version Update:** Upgraded Ruby to `3.3.6`.
+* **Inferno Core Update:** Bumped to version `0.6`.
+* **Gemspec Updates:**
+  * Switched to `git` for specifying files.
+  * Added `presets` to the gem package.
+  * Updated any test kit dependencies
+* **Test Kit Metadata:** Implemented Test Kit metadata for Inferno Platform.
+* **Environment Updates:** Updated Ruby version in the Dockerfile and GitHub Actions workflow.
+* Add Group IDs to Each Group in the CARIN Client Test Suite by @emichaud998 in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/61
+* Endpoint Suite ID Fix by @emichaud998 in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/62
+* FI-3404: Add SMART on FHIR Workflow Support to CARIN Client tests by @emichaud998 in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/63
+* Fix Metadata File Path by @emichaud998 in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/64
+* FI-3648: Add Spec for Shared Tests and Implement Features for the Failing Tests by @vanessuniq in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/65
+
 # 0.13.3
 
 * Deployment fixes by @karlnaden in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/59

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    carin_for_blue_button_test_kit (0.13.3)
+    carin_for_blue_button_test_kit (0.14.0)
       inferno_core (~> 0.6.2)
       smart_app_launch_test_kit (~> 0.5.0)
 
@@ -134,10 +134,11 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
-    httpclient (2.8.3)
+    httpclient (2.9.0)
+      mutex_m
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    inferno_core (0.6.2)
+    inferno_core (0.6.4)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -178,12 +179,12 @@ GEM
       base64
     kramdown (2.5.1)
       rexml (>= 3.3.9)
-    logger (1.6.5)
+    logger (1.6.6)
     method_source (1.1.0)
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0204)
+    mime-types-data (3.2025.0220)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
     multi_json (1.15.0)
@@ -195,6 +196,7 @@ GEM
     mustermann-contrib (1.1.2)
       hansi (~> 0.2.0)
       mustermann (= 1.1.2)
+    mutex_m (0.3.0)
     netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.18.2)

--- a/lib/carin_for_blue_button_test_kit/version.rb
+++ b/lib/carin_for_blue_button_test_kit/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module CarinForBlueButtonTestKit
-  VERSION = '0.13.3'
-  LAST_UPDATED = '2025-02-04'.freeze # TODO: update next release
+  VERSION = '0.14.0'
+  LAST_UPDATED = '2025-02-25'.freeze
 end


### PR DESCRIPTION
## Breaking Changes:
- **Ruby Version Update:** Upgraded Ruby to `3.3.6`.
- **Inferno Core Update:** Bumped to version `0.6`.
- **Gemspec Updates:**
  - Switched to `git` for specifying files.
  - Added `presets` to the gem package.
  - Updated any test kit dependencies
- **Test Kit Metadata:** Implemented Test Kit metadata for Inferno Platform.
- **Environment Updates:** Updated Ruby version in the Dockerfile and GitHub Actions workflow.
