### PR TITLE
FI-3995 Fix search template input description and regenerate

### DIFF
--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob_inpatient_institutional/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob_inpatient_institutional/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob_outpatient_institutional/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob_outpatient_institutional/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob_pharmacy/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob_pharmacy/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob_professional_non_clinician/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob_professional_non_clinician/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v1.1.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/coverage/id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/coverage/id_search_test.rb
@@ -28,13 +28,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :c4bb_v200devnonfinancial_coverage__id_search_test_param,
         title: 'Coverage search parameter for _id',
         type: 'text',
-        description: 'This input is optional. If running all tests, the search will look for
-                          its parameter values from the results returned in the EOB tests. If no
-                          Coverage resource was returned in previous EOB tests and this
-                          input is not provided, the search is skipped.
+        description: %q(
+          
+This input is optional. If running all tests, the search will look for
+its parameter values from the results returned in the EOB tests. If no
+Coverage resource was returned in previous EOB tests and this
+input is not provided, the search is skipped.
 
-                          When running just the Coverage Test group, this input is
-                          required to perform the search, otherwise the search is skipped.',
+When running just the Coverage Test group, this input is
+required to perform the search, otherwise the search is skipped.
+
+        ),
         optional: true
       
       def self.properties

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_inpatient_institutional/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_inpatient_institutional/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_inpatient_institutional_non_financial/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_inpatient_institutional_non_financial/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_oral/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_oral/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_oral_non_financial/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_oral_non_financial/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_outpatient_institutional/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_outpatient_institutional/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_outpatient_institutional_non_financial/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_outpatient_institutional_non_financial/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_pharmacy/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_pharmacy/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_pharmacy_non_financial/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_pharmacy_non_financial/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_professional_non_clinician/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_professional_non_clinician/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_professional_non_clinician_non_financial/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/eob_professional_non_clinician_non_financial/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/organization/id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/organization/id_search_test.rb
@@ -28,13 +28,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :c4bb_v200devnonfinancial_organization__id_search_test_param,
         title: 'Organization search parameter for _id',
         type: 'text',
-        description: 'This input is optional. If running all tests, the search will look for
-                          its parameter values from the results returned in the EOB tests. If no
-                          Organization resource was returned in previous EOB tests and this
-                          input is not provided, the search is skipped.
+        description: %q(
+          
+This input is optional. If running all tests, the search will look for
+its parameter values from the results returned in the EOB tests. If no
+Organization resource was returned in previous EOB tests and this
+input is not provided, the search is skipped.
 
-                          When running just the Organization Test group, this input is
-                          required to perform the search, otherwise the search is skipped.',
+When running just the Organization Test group, this input is
+required to perform the search, otherwise the search is skipped.
+
+        ),
         optional: true
       
       def self.properties

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient/id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/patient/id_search_test.rb
@@ -28,8 +28,12 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/practitioner/id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/practitioner/id_search_test.rb
@@ -28,13 +28,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :c4bb_v200devnonfinancial_practitioner__id_search_test_param,
         title: 'Practitioner search parameter for _id',
         type: 'text',
-        description: 'This input is optional. If running all tests, the search will look for
-                          its parameter values from the results returned in the EOB tests. If no
-                          Practitioner resource was returned in previous EOB tests and this
-                          input is not provided, the search is skipped.
+        description: %q(
+          
+This input is optional. If running all tests, the search will look for
+its parameter values from the results returned in the EOB tests. If no
+Practitioner resource was returned in previous EOB tests and this
+input is not provided, the search is skipped.
 
-                          When running just the Practitioner Test group, this input is
-                          required to perform the search, otherwise the search is skipped.',
+When running just the Practitioner Test group, this input is
+required to perform the search, otherwise the search is skipped.
+
+        ),
         optional: true
       
       def self.properties

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/related_person/id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0-dev-nonfinancial/related_person/id_search_test.rb
@@ -28,13 +28,17 @@ requirement of CARIN IG for Blue Button® v2.0.0-dev-nonfinancial.
       input :c4bb_v200devnonfinancial_related_person__id_search_test_param,
         title: 'RelatedPerson search parameter for _id',
         type: 'text',
-        description: 'This input is optional. If running all tests, the search will look for
-                          its parameter values from the results returned in the EOB tests. If no
-                          RelatedPerson resource was returned in previous EOB tests and this
-                          input is not provided, the search is skipped.
+        description: %q(
+          
+This input is optional. If running all tests, the search will look for
+its parameter values from the results returned in the EOB tests. If no
+RelatedPerson resource was returned in previous EOB tests and this
+input is not provided, the search is skipped.
 
-                          When running just the RelatedPerson Test group, this input is
-                          required to perform the search, otherwise the search is skipped.',
+When running just the RelatedPerson Test group, this input is
+required to perform the search, otherwise the search is skipped.
+
+        ),
         optional: true
       
       def self.properties

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/coverage/id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/coverage/id_search_test.rb
@@ -28,13 +28,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :c4bb_v200_coverage__id_search_test_param,
         title: 'Coverage search parameter for _id',
         type: 'text',
-        description: 'This input is optional. If running all tests, the search will look for
-                          its parameter values from the results returned in the EOB tests. If no
-                          Coverage resource was returned in previous EOB tests and this
-                          input is not provided, the search is skipped.
+        description: %q(
+          
+This input is optional. If running all tests, the search will look for
+its parameter values from the results returned in the EOB tests. If no
+Coverage resource was returned in previous EOB tests and this
+input is not provided, the search is skipped.
 
-                          When running just the Coverage Test group, this input is
-                          required to perform the search, otherwise the search is skipped.',
+When running just the Coverage Test group, this input is
+required to perform the search, otherwise the search is skipped.
+
+        ),
         optional: true
       
       def self.properties

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob_inpatient_institutional/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob_inpatient_institutional/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob_oral/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob_oral/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob_outpatient_institutional/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob_outpatient_institutional/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob_pharmacy/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob_pharmacy/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob_professional_non_clinician/patient_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/eob_professional_non_clinician/patient_search_test.rb
@@ -32,8 +32,12 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/organization/id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/organization/id_search_test.rb
@@ -28,13 +28,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :c4bb_v200_organization__id_search_test_param,
         title: 'Organization search parameter for _id',
         type: 'text',
-        description: 'This input is optional. If running all tests, the search will look for
-                          its parameter values from the results returned in the EOB tests. If no
-                          Organization resource was returned in previous EOB tests and this
-                          input is not provided, the search is skipped.
+        description: %q(
+          
+This input is optional. If running all tests, the search will look for
+its parameter values from the results returned in the EOB tests. If no
+Organization resource was returned in previous EOB tests and this
+input is not provided, the search is skipped.
 
-                          When running just the Organization Test group, this input is
-                          required to perform the search, otherwise the search is skipped.',
+When running just the Organization Test group, this input is
+required to perform the search, otherwise the search is skipped.
+
+        ),
         optional: true
       
       def self.properties

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient/id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/patient/id_search_test.rb
@@ -28,8 +28,12 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :patient_ids,
         title: 'Patient IDs',
         type: 'text',
-        description: 'Comma separated list of patient IDs that in sum
-                          contain all MUST SUPPORT elements'
+        description: %q(
+          
+Comma separated list of patient IDs that in sum
+contain all MUST SUPPORT elements
+
+        )
       
       def self.properties
         @properties ||= SearchTestProperties.new(

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/practitioner/id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/practitioner/id_search_test.rb
@@ -28,13 +28,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :c4bb_v200_practitioner__id_search_test_param,
         title: 'Practitioner search parameter for _id',
         type: 'text',
-        description: 'This input is optional. If running all tests, the search will look for
-                          its parameter values from the results returned in the EOB tests. If no
-                          Practitioner resource was returned in previous EOB tests and this
-                          input is not provided, the search is skipped.
+        description: %q(
+          
+This input is optional. If running all tests, the search will look for
+its parameter values from the results returned in the EOB tests. If no
+Practitioner resource was returned in previous EOB tests and this
+input is not provided, the search is skipped.
 
-                          When running just the Practitioner Test group, this input is
-                          required to perform the search, otherwise the search is skipped.',
+When running just the Practitioner Test group, this input is
+required to perform the search, otherwise the search is skipped.
+
+        ),
         optional: true
       
       def self.properties

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/related_person/id_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/related_person/id_search_test.rb
@@ -28,13 +28,17 @@ requirement of CARIN IG for Blue Button® v2.0.0.
       input :c4bb_v200_related_person__id_search_test_param,
         title: 'RelatedPerson search parameter for _id',
         type: 'text',
-        description: 'This input is optional. If running all tests, the search will look for
-                          its parameter values from the results returned in the EOB tests. If no
-                          RelatedPerson resource was returned in previous EOB tests and this
-                          input is not provided, the search is skipped.
+        description: %q(
+          
+This input is optional. If running all tests, the search will look for
+its parameter values from the results returned in the EOB tests. If no
+RelatedPerson resource was returned in previous EOB tests and this
+input is not provided, the search is skipped.
 
-                          When running just the RelatedPerson Test group, this input is
-                          required to perform the search, otherwise the search is skipped.',
+When running just the RelatedPerson Test group, this input is
+required to perform the search, otherwise the search is skipped.
+
+        ),
         optional: true
       
       def self.properties

--- a/lib/carin_for_blue_button_test_kit/generator/templates/search.rb.erb
+++ b/lib/carin_for_blue_button_test_kit/generator/templates/search.rb.erb
@@ -18,7 +18,9 @@ module CarinForBlueButtonTestKit
       input :<%=input_id%>,
         title: '<%=input_title.strip%>',
         type: 'text',
-        description: '<%=input_description.strip%>'<%if !needs_patient_id?%>,
+        description: %q(
+          <%=input_description.split("\n").map(&:strip).join("\n")%>
+        )<%if !needs_patient_id?%>,
         optional: true<% end %>
       <% end %>
       def self.properties


### PR DESCRIPTION
# Summary

Fix incorrect markdown formatting so the input descriptions for search tests don't overflow. This also fixes downstream test kits.

# Testing Guidance

Launch v2.0.0 server tests, select run tests, and visually inspect input form. 

