### PR TITLE
Release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.15.1
+* FI-3995 Fix search template input description and regenerate by @Shaumik-Ashraf in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/72
+* FI-3813: Use core MustSupport features by @dehall in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/70
+* FI-3662: verifies_requirements annotations by @elsaperelli in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/74
+* FI-3973: Client Auth by @karlnaden in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/73
+
 # 0.15.0
 ##Breaking Change
 This release updates the CARIN IG for Blue Button® Test Kit to use AuthInfo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    carin_for_blue_button_test_kit (0.15.0)
+    carin_for_blue_button_test_kit (0.15.1)
       inferno_core (~> 0.6.9)
       smart_app_launch_test_kit (~> 0.6.2)
       udap_security_test_kit (~> 0.11.4)
@@ -187,7 +187,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0507)
+    mime-types-data (3.2025.0514)
     mini_portile2 (2.8.9)
     minitest (5.25.5)
     multi_json (1.15.0)
@@ -277,7 +277,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
-    smart_app_launch_test_kit (0.6.2)
+    smart_app_launch_test_kit (0.6.3)
       inferno_core (>= 0.6.3)
       json-jwt (~> 1.15.3)
       jwt (~> 2.6)
@@ -308,7 +308,7 @@ GEM
     tty-screen (0.8.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    udap_security_test_kit (0.11.4)
+    udap_security_test_kit (0.11.5)
       inferno_core (>= 0.6.1)
       jwt (~> 2.3)
     unicode-display_width (2.6.0)

--- a/lib/carin_for_blue_button_test_kit/version.rb
+++ b/lib/carin_for_blue_button_test_kit/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module CarinForBlueButtonTestKit
-  VERSION = '0.15.0'
-  LAST_UPDATED = '2025-03-25'.freeze
+  VERSION = '0.15.1'
+  LAST_UPDATED = '2025-05-20'.freeze
 end


### PR DESCRIPTION
## What's Changed
* FI-3995 Fix search template input description and regenerate by @Shaumik-Ashraf in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/72
* FI-3813: Use core MustSupport features by @dehall in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/70
* FI-3662: verifies_requirements annotations by @elsaperelli in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/74
* FI-3973: Client Auth by @karlnaden in https://github.com/inferno-framework/carin-for-blue-button-test-kit/pull/73


