### PR TITLE
FI-3815 Update Test Kit with new RSpec features

### DIFF
--- a/spec/carin_for_blue_button/c4bb_client/c4bb_client_eob_required_searches_spec.rb
+++ b/spec/carin_for_blue_button/c4bb_client/c4bb_client_eob_required_searches_spec.rb
@@ -2,11 +2,11 @@ require_relative '../../../lib/carin_for_blue_button_test_kit/client/v2.0.0/clai
                  'patient_claims_data_request_test'
 
 RSpec.describe CarinForBlueButtonTestKit::C4BBClientEOBRequiredSearches do
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('c4bb_v200_client') }
+  let(:suite_id) { 'c4bb_v200_client' }
+  let(:suite) { Inferno::Repositories::TestSuites.new.find(suite_id) }
   let(:test) { Inferno::Repositories::Tests.new.find('eob_required_searches') }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:results_repo) { Inferno::Repositories::Results.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: 'c4bb_v200_client') }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite_id) }
   let(:result) { repo_create(:result, test_session_id: test_session.id) }
 
   let(:c4bb_eob_include_bundle) do
@@ -162,20 +162,6 @@ RSpec.describe CarinForBlueButtonTestKit::C4BBClientEOBRequiredSearches do
       headers:,
       tags:
     )
-  end
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name:,
-        value:,
-        type: runnable.config.input_type(name) || 'text'
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
   it 'passes if successful FHIR search requests for all required searches for EOB was made' do

--- a/spec/carin_for_blue_button/c4bb_client/c4bb_client_initial_wait_test_spec.rb
+++ b/spec/carin_for_blue_button/c4bb_client/c4bb_client_initial_wait_test_spec.rb
@@ -5,11 +5,10 @@ RSpec.describe CarinForBlueButtonTestKit::C4BBClientInitialWaitTest do
   include Rack::Test::Methods
   include RequestHelpers
 
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('c4bb_v200_client') }
+  let(:suite_id) { 'c4bb_v200_client' }
+  let(:suite) { Inferno::Repositories::TestSuites.new.find(suite_id) }
   let(:test) { Inferno::Repositories::Tests.new.find('c4bb_v200_initial_wait_test') }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:results_repo) { Inferno::Repositories::Results.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: 'c4bb_v200_client') }
 
   let(:base_url) { "#{Inferno::Application['base_url']}/custom/c4bb_v200_client/fhir" }
   let(:fhir_server) { ENV.fetch('FHIR_REFERENCE_SERVER') }
@@ -59,21 +58,6 @@ RSpec.describe CarinForBlueButtonTestKit::C4BBClientInitialWaitTest do
                           resource: FHIR.from_contents(c4bb_patient_resource.to_json)
                         ))
     bundle
-  end
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name:,
-        value:,
-        type: runnable.config.input_type(name)
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
   it 'Passes and responds 200 if valid Patient API request sent to the provided URL and Bearer token is correct' do

--- a/spec/carin_for_blue_button/c4bb_client/c4bb_client_patient_submit_claims_data_request_test_spec.rb
+++ b/spec/carin_for_blue_button/c4bb_client/c4bb_client_patient_submit_claims_data_request_test_spec.rb
@@ -2,11 +2,10 @@ require_relative '../../../lib/carin_for_blue_button_test_kit/client/v2.0.0/clai
                  'patient_claims_data_request_test'
 
 RSpec.describe CarinForBlueButtonTestKit::C4BBClientPatientSubmitClaimsDataRequestTest do
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('c4bb_v200_client') }
+  let(:suite_id) { 'c4bb_v200_client' }
+  let(:suite) { Inferno::Repositories::TestSuites.new.find(suite_id) }
   let(:test) { Inferno::Repositories::Tests.new.find('patient_claims_data_request_test') }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:results_repo) { Inferno::Repositories::Results.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: 'c4bb_v200_client') }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite_id) }
   let(:result) { repo_create(:result, test_session_id: test_session.id) }
 
   let(:c4bb_patient_resource) do
@@ -84,20 +83,6 @@ RSpec.describe CarinForBlueButtonTestKit::C4BBClientPatientSubmitClaimsDataReque
       headers:,
       tags:
     )
-  end
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name:,
-        value:,
-        type: runnable.config.input_type(name) || 'text'
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
   it 'passes if successful FHIR API request for Patient resource with _id parameter' do

--- a/spec/carin_for_blue_button/carin_search_test_spec.rb
+++ b/spec/carin_for_blue_button/carin_search_test_spec.rb
@@ -1,27 +1,11 @@
-RSpec.describe CarinForBlueButtonTestKit::CarinSearchTest do
+RSpec.describe CarinForBlueButtonTestKit::CarinSearchTest, :runnable do
   let(:eob_json_string) do
     File.read(File.join(__dir__, '..', 'fixtures', 'c4bb_eob_inpatient_example.json'))
   end
 
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('c4bb_v200') }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:suite_id) { 'c4bb_v200' }
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name:,
-        value:,
-        type: runnable.config.input_type(name)
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
 
   def setup_mock_test(search_test, eob_resource)
     allow_any_instance_of(search_test).to receive(:scratch_resources).and_return(

--- a/spec/carin_for_blue_button/must_support_test_spec.rb
+++ b/spec/carin_for_blue_button/must_support_test_spec.rb
@@ -1,30 +1,12 @@
-RSpec.describe CarinForBlueButtonTestKit::MustSupportTest do
+RSpec.describe CarinForBlueButtonTestKit::MustSupportTest, :runnable do
 
   let(:json_string_stub) do
     File.read(File.join(__dir__, '..', 'fixtures', 'c4bb_patient_stub.json'))
   end
 
-  let(:patient_must_support_test) { Inferno::Repositories::Tests.new.find('c4bb_v200_patient_must_support_test')}
+  let(:patient_must_support_test) { Inferno::Repositories::Tests.new.find('c4bb_v200_patient_must_support_test') }
 
-  # copied from us-core-test-kit
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('c4bb_v200') }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(
-      test_session_id: test_session.id,
-      name: name,
-      value: value,
-      type: runnable.config.input_type(name)
-      )
-    end
-    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
-  end
-
+  let(:suite_id) { 'c4bb_v200' }
 
   def generate_patient_resource(json_addition)
     complete_json_string = json_string_stub + json_addition

--- a/spec/carin_for_blue_button/read_test_spec.rb
+++ b/spec/carin_for_blue_button/read_test_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe CarinForBlueButtonTestKit::ReadTest do
+RSpec.describe CarinForBlueButtonTestKit::ReadTest, :runnable do
   let(:patient_json_string) do
     File.read(File.join(__dir__, '..', 'fixtures', 'c4bb_patient_example.json'))
   end
@@ -7,9 +7,7 @@ RSpec.describe CarinForBlueButtonTestKit::ReadTest do
     File.read(File.join(__dir__, '..', 'fixtures', 'c4bb_organization_example.json'))
   end
 
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('c4bb_v200') }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:suite_id) { 'c4bb_v200' }
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
 
@@ -19,21 +17,6 @@ RSpec.describe CarinForBlueButtonTestKit::ReadTest do
   let(:patient_id_1) { 'Patient1' }
   let(:patient_id_2) { 'Patient2' }
   let(:patient_ids) { 'Patient1, Patient2' }
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name:,
-        value:,
-        type: runnable.config.input_type(name)
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
 
   def setup_mock_test(search_test, patient_resources)
     allow_any_instance_of(search_test).to receive(:scratch_resources).and_return(

--- a/spec/carin_for_blue_button/validation_test_spec.rb
+++ b/spec/carin_for_blue_button/validation_test_spec.rb
@@ -1,29 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe CarinForBlueButtonTestKit::ValidationTest do
+RSpec.describe CarinForBlueButtonTestKit::ValidationTest, :runnable do
   let(:patient_json_string) do
     File.read(File.join(__dir__, '..', 'fixtures', 'c4bb_patient_example.json'))
   end
 
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('c4bb_v200') }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:suite_id) { 'c4bb_v200' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name:,
-        value:,
-        type: runnable.config.input_type(name)
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
 
   def setup_mock_test(search_test, patient_resources)
     allow_any_instance_of(search_test).to receive(:scratch_resources).and_return(


### PR DESCRIPTION
# Summary

 - Uses `run` for RSpec from inferno_core instead of defining it locally

# Testing Guidance

1. Checkout branch
2. `bundle exec rake`
