### PR TITLE
made inputs not prompt for url when running validation tests. added i…

### DIFF
--- a/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/urls.rb
+++ b/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/urls.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module CarinForBlueButtonTestKit
+    RESUME_PASS_PATH = '/resume_pass'
+    RESUME_FAIL_PATH = '/resume_fail'
+
+    # URLs
+    module URLs
+      def base_url
+        @base_url ||= "#{Inferno::Application['base_url']}/custom/#{suite_id}"
+      end
+
+      def resume_pass_url
+        @resume_pass_url ||= base_url + RESUME_PASS_PATH
+      end
+
+      def resume_fail_url
+        @resume_fail_url ||= base_url + RESUME_FAIL_PATH
+      end
+
+      def suite_id
+        C4BBTestSuite.id
+      end
+    end
+end

--- a/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_client.rb
+++ b/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_client.rb
@@ -1,3 +1,4 @@
+require_relative 'urls'
 require_relative 'v200_client/must_support_display'
 require_relative 'v200_client/must_support_missing'
 require_relative 'v200_client/must_support_absent_reason'
@@ -6,6 +7,8 @@ require_relative 'v200_client/authentication'
 
 module CarinForBlueButtonTestKit
   class CarinClientVisualInspectionAndAttestationGroup < Inferno::TestGroup
+    include URLs
+
     id :c4bb_client_v200_visual_inspection_and_attestation
 
     title 'Visual Inspection and Attestation'

--- a/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server.rb
+++ b/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server.rb
@@ -1,3 +1,4 @@
+require_relative 'urls'
 require_relative 'v200_server/00_authorization_group'
 require_relative 'v200_server/01_must_support_group'
 require_relative 'v200_server/03_eob_group'
@@ -12,6 +13,8 @@ require_relative 'v200_server/11_crosscutting_group'
 
 module CarinForBlueButtonTestKit
   class CarinServerVisualInspectionAndAttestationGroup < Inferno::TestGroup
+    include URLs
+
     id :c4bb_server_v200_visual_inspection_and_attestation
 
     title 'Visual Inspection and Attestation'

--- a/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/01_must_support_group/attestation_test_requirement_10.rb
+++ b/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/01_must_support_group/attestation_test_requirement_10.rb
@@ -18,6 +18,7 @@ module CarinForBlueButtonTestKit
           when the source system lacks data for required elements with minimum cardinality > 0.
 
           [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
+
           [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
         MESSAGE
       )

--- a/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/01_must_support_group/attestation_test_requirement_9.rb
+++ b/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/01_must_support_group/attestation_test_requirement_9.rb
@@ -18,6 +18,7 @@ module CarinForBlueButtonTestKit
           when the source system has no data available for them.
 
           [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
+
           [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
         MESSAGE
       )

--- a/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/03_eob_group/attestation_test_requirement_115.rb
+++ b/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/03_eob_group/attestation_test_requirement_115.rb
@@ -16,6 +16,7 @@ module CarinForBlueButtonTestKit
           I attest that the Health IT Module does **not** assign a data absent reason to `ExplanationOfBenefit.type`.
 
           [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
+
           [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
         MESSAGE
       )

--- a/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/05_eob_outpatient_group/attestation_test_requirement_156.rb
+++ b/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/05_eob_outpatient_group/attestation_test_requirement_156.rb
@@ -20,6 +20,7 @@ module CarinForBlueButtonTestKit
           - When line item amounts are not available, claim-level amounts and amount types are provided in `EOB.header`.
 
           [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
+
           [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
         MESSAGE
       )

--- a/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/11_crosscutting_group/attestation_test_requirement_19.rb
+++ b/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/11_crosscutting_group/attestation_test_requirement_19.rb
@@ -19,6 +19,7 @@ module CarinForBlueButtonTestKit
           for that code by the code system (which may allow multiple valid display strings).
 
           [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
+
           [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
         MESSAGE
       )

--- a/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/11_crosscutting_group/attestation_test_requirement_28.rb
+++ b/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/11_crosscutting_group/attestation_test_requirement_28.rb
@@ -18,6 +18,7 @@ module CarinForBlueButtonTestKit
           vocabulary standards, and code sets outlined in the specification.
 
           [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
+
           [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
         MESSAGE
       )

--- a/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/11_crosscutting_group/attestation_test_requirement_99.rb
+++ b/lib/carin_for_blue_button_test_kit/custom_groups/visual_inspection_and_attestation/v200_server/11_crosscutting_group/attestation_test_requirement_99.rb
@@ -18,6 +18,7 @@ module CarinForBlueButtonTestKit
           CARIN-BB profile URL(s) in the `meta.profile` element.
 
           [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
+
           [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
         MESSAGE
       )

--- a/lib/carin_for_blue_button_test_kit/generated/v2.0.0/c4bb_test_suite.rb
+++ b/lib/carin_for_blue_button_test_kit/generated/v2.0.0/c4bb_test_suite.rb
@@ -117,9 +117,15 @@ module CarinForBlueButtonTestKit
         group from: :c4bb_v200_practitioner
         group from: :c4bb_v200_related_person
       end
-      group from: :c4bb_server_v200_visual_inspection_and_attestation do
-        optional
+      group from: :c4bb_server_v200_visual_inspection_and_attestation,
+        optional: true
+
+      def self.recursive_remove_input(runnable, input)
+          runnable.inputs.delete(input)
+          runnable.input_order.delete(input)
+          runnable.children.each { |child_runnable| recursive_remove_input(child_runnable, input) }
       end
+      recursive_remove_input(groups.last, :url)
     end
   end
 end

--- a/lib/carin_for_blue_button_test_kit/generator/templates/suite.rb.erb
+++ b/lib/carin_for_blue_button_test_kit/generator/templates/suite.rb.erb
@@ -110,9 +110,16 @@ module CarinForBlueButtonTestKit
     <% group_id_list.each do |id| %>
         group from: :<%= id %><% end %>
       end
-      <%- if module_name == "CARIN4BBV200" -%>      group from: :c4bb_server_v200_visual_inspection_and_attestation do
-        optional
+      <%- if module_name == "CARIN4BBV200" -%>
+      group from: :c4bb_server_v200_visual_inspection_and_attestation,
+        optional: true
+
+      def self.recursive_remove_input(runnable, input)
+          runnable.inputs.delete(input)
+          runnable.input_order.delete(input)
+          runnable.children.each { |child_runnable| recursive_remove_input(child_runnable, input) }
       end
+      recursive_remove_input(groups.last, :url)
       <%- end -%>
     end
   end


### PR DESCRIPTION
# Summary
Removes the url input request when running visual inspection and attestation tests

Addressed missing URLs issue.

# Testing Guidance
- Open client suite
- Go to visual inspection and attestation tests
- Run tests and confirm that nothing requests a fhir url
- Run tests and confirm you get pass/fails and no purple errors
- Repeat for server suite

