### PR TITLE
ID-107: check types of values returned from resolve_path

### DIFF
--- a/lib/carin_for_blue_button_test_kit/carin_search_test.rb
+++ b/lib/carin_for_blue_button_test_kit/carin_search_test.rb
@@ -423,7 +423,7 @@ module CarinForBlueButtonTestKit
     def matched_base_resources(_resource, referenced_resource_types, returned_resources_all, values_found)
       included_refs = included_refs(returned_resources_all, referenced_resource_types)
 
-      values_found.select do |base_resource_references|
+      values_found.select { |value| value.is_a?(FHIR::Reference) }.select do |base_resource_references|
         included_refs.any? do |referenced_resource|
           reference_match?(base_resource_references.reference, referenced_resource)
         end

--- a/spec/carin_for_blue_button/carin_search_test_spec.rb
+++ b/spec/carin_for_blue_button/carin_search_test_spec.rb
@@ -432,6 +432,30 @@ RSpec.describe CarinForBlueButtonTestKit::CarinSearchTest, :runnable do
       expect(result.result_message).to eq('No ExplanationOfBenefit references Patient/456 in the search result.')
       expect(request).to have_been_made.once
     end
+
+    it 'does not raise an exception when the base resource has a non-Reference value at the include path' do
+      # An invalid resource may have a primitive string where a Reference object is expected.
+      # resolve_path returns whatever is stored, so matched_base_resources must guard against non-Reference values.
+      malformed_bundle_json = {
+        resourceType: 'Bundle',
+        entry: [
+          {
+            resource: {
+              resourceType: 'ExplanationOfBenefit',
+              id: explanation_of_benefit_id,
+              patient: "Patient/#{patient_id}" # string instead of {"reference": "..."}
+            }
+          },
+          { resource: JSON.parse(patient.to_json) }
+        ]
+      }.to_json
+
+      request = stub_request(:get, "#{url}/ExplanationOfBenefit?#{search_params_patient}")
+                .to_return(status: 200, body: malformed_bundle_json)
+
+      expect { run(explanation_of_benefit_include_test_patient, url:) }.not_to raise_error
+      expect(request).to have_been_made.once
+    end
   end
 
   describe 'search ExplanationofBenefit with _include * param' do


### PR DESCRIPTION
# Summary

A recent [update to the fhir navigation logic in inferno-core](https://github.com/inferno-framework/inferno-core/pull/770) improved the ability of the resolve_path function. This resulted in some tests failing with purple errors due to unsafe use of the resolve_path function that didn't check the types of the returned values before accessing their properties. This update ensures that all uses of resolve_path are safe.

# Testing Guidance

No explicit test failure was detected, so this is a preemptive fix. A spec test was added and you can run the v2.0.0 server tests to verify that no purple errors occur, specifically in tests involving checking of includes like 2.3.09 and 2.4.03.

inputs for test run:
```
[
  {
    "name": "patient_ids",
    "description": "Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements",
    "title": "Patient IDs",
    "type": "text",
    "value": "888"
  },
  {
    "name": "url",
    "description": "URL of the FHIR endpoint",
    "title": "FHIR Endpoint",
    "type": "text",
    "value": "https://inferno.healthit.gov/reference-server/r4"
  },
  {
    "name": "smart_auth_info",
    "optional": true,
    "title": "OAuth Credentials",
    "type": "auth_info",
    "value": {
      "access_token": "SAMPLE_TOKEN",
      "refresh_token": "",
      "client_id": "",
      "token_url": "",
      "issue_time": "",
      "expires_in": "",
      "auth_type": "public"
    },
    "default": {}
  }
]
```